### PR TITLE
feat(nvim): add telescope.nvim fuzzy finder

### DIFF
--- a/private_dot_config/nvim/lua/edgissa/plugins/telescope.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/telescope.lua
@@ -1,0 +1,32 @@
+return {
+  "nvim-telescope/telescope.nvim",
+  branch = "0.1.x",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+  },
+  cmd = "Telescope",
+  keys = {
+    { "<leader>ff", "<cmd>Telescope find_files<cr>", desc = "Find files" },
+    { "<leader>fg", "<cmd>Telescope live_grep<cr>", desc = "Live grep" },
+    { "<leader>fb", "<cmd>Telescope buffers<cr>", desc = "Buffers" },
+    { "<leader>fh", "<cmd>Telescope help_tags<cr>", desc = "Help tags" },
+    { "<leader>fs", "<cmd>Telescope lsp_document_symbols<cr>", desc = "Document symbols" },
+    { "gr", "<cmd>Telescope lsp_references<cr>", desc = "LSP References" },
+  },
+  config = function()
+    local telescope = require("telescope")
+    telescope.setup({
+      defaults = {
+        file_ignore_patterns = { "node_modules", ".git/" },
+        mappings = {
+          i = {
+            ["<C-j>"] = "move_selection_next",
+            ["<C-k>"] = "move_selection_previous",
+          },
+        },
+      },
+    })
+    telescope.load_extension("fzf")
+  end,
+}


### PR DESCRIPTION
## Summary
- telescope.nvim + telescope-fzf-native.nvim を追加
- キーマップ: `<leader>ff` (files), `<leader>fg` (grep), `<leader>fb` (buffers), `<leader>fh` (help), `<leader>fs` (symbols), `gr` (references)

Closes #23