### PR TITLE
refactor(zsh): centralize PATH management

### DIFF
--- a/dot_zshenv
+++ b/dot_zshenv
@@ -3,13 +3,24 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 export LC_CTYPE=en_US.UTF-8
 
+# Prevent duplicate PATH entries
+typeset -U path
+
+# --- PATH management (all PATH settings belong here) ---
+
+# Volta (Node.js manager)
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
+
+# Go
 export PATH="/usr/local/go/bin:$PATH"
 export PATH="$HOME/go/bin:$PATH"
 
-# uv, uvx
+# Atuin (shell history)
+[ -f "$HOME/.atuin/bin/env" ] && . "$HOME/.atuin/bin/env"
+
+# uv, uvx (Python)
 [ -f "$HOME/.local/bin/env" ] && source "$HOME/.local/bin/env"
 
-# load cargo (rust) env
+# Cargo (Rust)
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -31,11 +31,6 @@ command -v eza &> /dev/null && alias ls='eza --icons --group --git --group-direc
 # alias claude="$HOME/.claude/local/claude"
 {{ end }}
 
-# Atuin: modern shell history tool
-if [ -f "$HOME/.atuin/bin/env" ]; then
-  . "$HOME/.atuin/bin/env"
-fi
-
 # zsh plugin
 command -v sheldon >/dev/null 2>&1 && eval "$(sheldon source)"
 command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"


### PR DESCRIPTION
## Summary
- Add `typeset -U path` to prevent PATH duplication
- Organize tool-specific PATHs with clear comments (Volta, Go, Cargo, uv)
- Move Atuin env sourcing from zshrc to zshenv (PATH-related)
- Keep interactive tool init (sheldon, starship, direnv, fzf) in zshrc

Closes #36