### PR TITLE
feat(nvim): add catppuccin colorscheme

### DIFF
--- a/private_dot_config/nvim/lua/edgissa/plugins/colorscheme.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/colorscheme.lua
@@ -19,6 +19,6 @@ return {
       },
     })
 
-    vim.cmd.colorscheme("catppuccin-mocha")
+    vim.cmd.colorscheme("catppuccin")
   end,
 }

--- a/private_dot_config/nvim/lua/edgissa/plugins/colorscheme.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/colorscheme.lua
@@ -1,0 +1,24 @@
+return {
+  "catppuccin/nvim",
+  name = "catppuccin",
+  priority = 1000,
+  config = function()
+    require("catppuccin").setup({
+      flavour = "mocha",
+      integrations = {
+        cmp = true,
+        gitsigns = true,
+        treesitter = true,
+        telescope = { enabled = true },
+        diffview = true,
+        neotree = true,
+        which_key = true,
+        native_lsp = {
+          enabled = true,
+        },
+      },
+    })
+
+    vim.cmd.colorscheme("catppuccin-mocha")
+  end,
+}


### PR DESCRIPTION
## Summary
- Add catppuccin/nvim as the default colorscheme (mocha variant)
- Configure integrations for all existing plugins (treesitter, telescope, gitsigns, diffview, neo-tree, cmp, which-key, native LSP)
- lualine already references catppuccin theme, no change needed

Closes #32