### PR TITLE
feat(tmux): replace manual theme with catppuccin-mocha

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -32,29 +32,14 @@ bind c new-window -c "#{pane_current_path}"
 bind r source-file ~/.tmux.conf \; display "Config Reloaded!"
 
 # -----------------------
-# Color Config
+# Status Bar
 # -----------------------
-status_bg_color='black'
-status_fg_color='white'
-
-# -----------------------
-# Status Bar Config
-# -----------------------
-set -g status-style fg=$status_fg_color,bg=$status_bg_color
-set -g status-left-length 100
-set -g status-right-length 120
-set -g status-justify absolute-centre
 set -g status-position top
 set -g status-interval 1
-set -g status-left " #[fg=green]Session: #S #[fg=yellow]Window #I #[fg=cyan]Pane: #P  #{prefix_highlight}"
-set -g status-right " #[fg=cyan][%Y-%m-%d(%a) %H:%M:%S] #{weather} "
+set -g status-justify absolute-centre
+set -g status-left-length 100
+set -g status-right-length 120
 set -g focus-events on
-
-# Window list colors
-setw -g window-status-style fg=cyan,bg=default,dim
-setw -g window-status-current-style fg=cyan,bg=red,bright
-set -g window-status-format '#[fg=colour196]#I:#(pwd="#{pane_current_path}"; echo ${pwd####*/})'
-set -g window-status-current-format '#[fg=colour255,bg=colour124][#I:#(pwd="#{pane_current_path}"; echo ${pwd####*/})]'
 
 # -----------------------
 # Bell Config (for Claude Code notifications)
@@ -67,8 +52,6 @@ set -g window-status-bell-style 'fg=red,bg=black,bold,blink'
 # -----------------------
 # Pane Style
 # -----------------------
-set -g window-style 'bg=colour239'
-set -g window-active-style 'bg=colour234'
 set -sa terminal-overrides ',xterm-256color:RGB'
 
 # -----------------------
@@ -82,28 +65,23 @@ bind -T copy-mode C-u send-keys -X page-up
 bind -T copy-mode C-d send-keys -X page-down
 
 # -----------------------
+# Catppuccin Theme
+# -----------------------
+set -g @catppuccin_flavor "mocha"
+set -g @catppuccin_window_status_style "rounded"
+set -g @catppuccin_status_modules_right "directory session date_time"
+set -g @catppuccin_date_time_text "%Y-%m-%d %H:%M"
+
+# -----------------------
 # Plugin Config
 # -----------------------
-set -g @plugin 'tmux-plugins/tpm' # tmuxのplugin manager
-set -g @plugin 'tmux-plugins/tmux-resurrect' # PCを再起動してもセッションを復帰できるようにする
-set -g @plugin 'tmux-plugins/tmux-continuum' # tmux-resurrectを自動で操作する
-set -g @plugin 'tmux-plugins/tmux-yank' # tmuxのヤンクをOSのクリップボードと共有する
-set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
-set -g @plugin 'xamut/tmux-weather'
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'thewtex/tmux-mem-cpu-load'
+set -g @plugin 'catppuccin/tmux'
 
-set -g @continuum-restore 'on' # tmux実行時に自動的セッションをリストア
-
-set -g @prefix_highlight_bg 'white'
-set -g @prefix_highlight_fg 'cyan'
-set -g @prefix_highlight_show_copy_mode 'on'
-set -g @prefix_highlight_copy_prompt 'Copy'
-set -g @prefix_highlight_show_sync_mode 'on'
-set -g @prefix_highlight_sync_prompt 'Sync'
-set -g @prefix_highlight_sync_mode_attr 'fg=default,bg=green'
-
-set -g @tmux-weather-location "Tokyo"
-set -g @tmux-weather-format "%l:+%c+%t"
-set -g @tmux-weather-units "m"
+set -g @continuum-restore 'on'
 
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary
- Add catppuccin/tmux plugin with mocha flavour to unify with Neovim (#32)
- Remove manual color/status bar configuration (catppuccin handles it)
- Remove tmux-prefix-highlight and tmux-weather plugins (replaced by catppuccin modules)
- Configure status modules: directory, session, date_time
- Keep resurrect, continuum, yank, mem-cpu-load plugins

Closes #38