### PR TITLE
feat(ci): add pre-commit hooks and stylua config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: ["-s", "bash", "-e", "SC1091"]
+        files: \.sh(\.tmpl)?$
+
+  - repo: https://github.com/JohnnyMorganz/StyLua
+    rev: v2.0.2
+    hooks:
+      - id: stylua
+        args: ["--check"]
+        files: \.lua$
+
+  - repo: local
+    hooks:
+      - id: chezmoi-template-check
+        name: chezmoi template validation
+        entry: sh -c 'for f in "$@"; do chezmoi execute-template < "$f" > /dev/null || exit 1; done' --
+        language: system
+        files: \.tmpl$
+        types: [file]

--- a/.stylua.toml
+++ b/.stylua.toml
@@ -1,0 +1,4 @@
+column_width = 120
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferDouble"


### PR DESCRIPTION
## Summary
- Add pre-commit framework with hooks for shellcheck, stylua, TOML/YAML validation
- Add local chezmoi template validation hook (`chezmoi execute-template`)
- Add `.stylua.toml` for Lua formatting standards (2-space indent, 120 col width)
- Shellcheck exclusions match existing CI config (SC1091)

Closes #42