### PR TITLE
feat(chezmoi): add macOS support with Homebrew integration

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -8,6 +8,11 @@ typeset -U path
 
 # --- PATH management (all PATH settings belong here) ---
 
+{{ if eq .chezmoi.os "darwin" -}}
+# Homebrew
+eval "$(/opt/homebrew/bin/brew shellenv)"
+{{ end -}}
+
 # Volta (Node.js manager)
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"

--- a/private_dot_config/zsh/aliases.zsh.tmpl
+++ b/private_dot_config/zsh/aliases.zsh.tmpl
@@ -15,3 +15,11 @@ command -v eza &> /dev/null && alias ls='eza --icons --group --git --group-direc
 # global claude
 # alias claude="$HOME/.claude/local/claude"
 {{ end }}
+
+{{ if eq .chezmoi.os "darwin" }}
+# ls command
+command -v eza &> /dev/null && alias ls='eza --icons --group --git --group-directories-first' || alias ls='ls --color=auto -h'
+
+# open shortcut (consistent with Linux xdg-open)
+alias xdg-open='open'
+{{ end }}

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+if [ -n "${CI:-}" ]; then
+  echo "CI environment detected. Skipping Homebrew installation."
+  exit 0
+fi
+
+{{ if eq .chezmoi.os "darwin" }}
+echo "Installing Homebrew and core packages for macOS"
+
+# Install Homebrew if not present
+if ! command -v brew >/dev/null 2>&1; then
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+  # Add Homebrew to PATH for the rest of this script
+  if [ -f /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
+fi
+
+# Core packages
+brew install \
+  eza \
+  fzf \
+  ghq \
+  sheldon \
+  starship \
+  atuin \
+  direnv \
+  neovim \
+  ripgrep \
+  fd \
+  bat
+{{ end }}


### PR DESCRIPTION
## Summary
- Add `run_once_install-homebrew.sh.tmpl` for macOS package installation via Homebrew
- Rename `dot_zshenv` → `dot_zshenv.tmpl` for OS-conditional PATH (Homebrew on darwin)
- Add macOS-specific aliases (eza, xdg-open→open)

Closes #39