### PR TITLE
fix(chezmoi): exclude non-dotfiles from chezmoi apply

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,2 +1,12 @@
-# Claude Code skills - should not be managed by chezmoi
+# Repository-only files (not dotfiles)
+CLAUDE.md
+README.md
+docs/
+.pre-commit-config.yaml
+.stylua.toml
+
+# Claude Code auto-generated / transient files
 .claude/skills/
+.claude/.update.lock
+.claude/shell-snapshots
+.claude/plugins/

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -8,5 +8,5 @@ docs/
 # Claude Code auto-generated / transient files
 .claude/skills/
 .claude/.update.lock
-.claude/shell-snapshots
+.claude/shell-snapshots/
 .claude/plugins/


### PR DESCRIPTION
## Summary
- `.chezmoiignore` にリポジトリ専用ファイル（`CLAUDE.md`, `README.md`, `docs/`, `.pre-commit-config.yaml`, `.stylua.toml`）を追加
- Claude Code の一時/自動生成ファイル（`.update.lock`, `shell-snapshots`, `plugins/`）を除外対象に追加
- `chezmoi apply` 時にホームディレクトリへ不要なファイルがデプロイされるのを防止

## Test plan
- [ ] `chezmoi managed` で除外対象が含まれていないことを確認
- [ ] `chezmoi apply --dry-run` で不要なファイルが対象外であることを確認