### PR TITLE
feat(install): add run_onchange script for fzf

### DIFF
--- a/run_once_install-linux-packages.sh.tmpl
+++ b/run_once_install-linux-packages.sh.tmpl
@@ -14,9 +14,9 @@ log "Installing system packages and Go tools"
 sudo apt update
 
 # Development tools
-if ! command -v fzf >/dev/null 2>&1; then
+if ! command -v htop >/dev/null 2>&1; then
   log "Installing development tools..."
-  sudo apt install -y fzf htop build-essential libssl-dev pkg-config cmake
+  sudo apt install -y htop build-essential libssl-dev pkg-config cmake
 
   # x11
   sudo apt install -y xclip

--- a/run_onchange_install-fzf.sh.tmpl
+++ b/run_onchange_install-fzf.sh.tmpl
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# fzf version: 0.70.0
+
+log() { echo "[install] $*"; }
+
+if [ -n "${CI:-}" ]; then
+  log "CI environment detected. Skipping fzf installation."
+  exit 0
+fi
+
+{{ if eq .chezmoi.os "linux" }}
+
+FZF_VERSION="0.70.0"
+
+if command -v fzf >/dev/null 2>&1; then
+  CURRENT_VERSION=$(fzf --version | awk '{print $1}')
+  if [ "$CURRENT_VERSION" = "$FZF_VERSION" ]; then
+    log "fzf is already up to date: ${CURRENT_VERSION}"
+    exit 0
+  fi
+fi
+
+log "Installing fzf ${FZF_VERSION}..."
+
+arch=$(uname -m)
+case "$arch" in
+  x86_64)  fzf_arch="linux_amd64" ;;
+  aarch64) fzf_arch="linux_arm64" ;;
+  *) log "Unsupported architecture: $arch"; exit 1 ;;
+esac
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-${fzf_arch}.tar.gz" \
+  -o "$tmpdir/fzf.tar.gz"
+tar -xzf "$tmpdir/fzf.tar.gz" -C "$tmpdir"
+
+install -Dm755 "$tmpdir/fzf" "${HOME}/.local/bin/fzf"
+
+log "fzf ${FZF_VERSION} installed to ~/.local/bin/fzf"
+
+{{ end }}


### PR DESCRIPTION
## Summary
- GitHub releases から fzf バイナリを `~/.local/bin` にインストールする `run_onchange` スクリプトを追加
- apt 版 fzf (0.44.1) では `--zsh` オプションが未サポートで `unknown option: --zsh` エラーが発生していた
- `run_once_install-linux-packages.sh.tmpl` から fzf の apt インストールを除外

## Test plan
- [x] `chezmoi execute-template` でテンプレートが正常に展開されることを確認
- [x] fzf 0.70.0 が `~/.local/bin/fzf` にインストールされることを確認
- [x] `fzf --zsh` が正常に動作することを確認