### PR TITLE
fix(nvim): migrate treesitter config to new API

### DIFF
--- a/private_dot_config/nvim/lua/edgissa/plugins/treesitter.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/treesitter.lua
@@ -1,90 +1,94 @@
+local parsers = {
+  "bash",
+  "css",
+  "dockerfile",
+  "go",
+  "html",
+  "json",
+  "lua",
+  "markdown",
+  "markdown_inline",
+  "python",
+  "rust",
+  "toml",
+  "tsx",
+  "typescript",
+  "yaml",
+}
+
 return {
   {
     "nvim-treesitter/nvim-treesitter",
-    event = { "BufReadPre", "BufNewFile" },
+    lazy = false,
     build = ":TSUpdate",
-    dependencies = {
-      "nvim-treesitter/nvim-treesitter-textobjects",
-    },
     config = function()
-      require("nvim-treesitter.configs").setup({
-        ensure_installed = {
-          "bash",
-          "css",
-          "dockerfile",
-          "go",
-          "html",
-          "json",
-          "lua",
-          "markdown",
-          "python",
-          "rust",
-          "toml",
-          "tsx",
-          "typescript",
-          "yaml",
+      local ts = require("nvim-treesitter")
+      local installed = ts.get_installed()
+
+      local to_install = {}
+      for _, parser in ipairs(parsers) do
+        if not vim.list_contains(installed, parser) then
+          table.insert(to_install, parser)
+        end
+      end
+      if #to_install > 0 then
+        ts.install(to_install)
+      end
+
+      vim.api.nvim_create_autocmd("FileType", {
+        callback = function(args)
+          local ft = args.match
+          local lang = vim.treesitter.language.get_lang(ft) or ft
+          local ok = pcall(vim.treesitter.language.inspect, lang)
+          if ok then
+            vim.treesitter.start()
+            vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+          end
+        end,
+      })
+    end,
+  },
+  {
+    "nvim-treesitter/nvim-treesitter-textobjects",
+    lazy = false,
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    config = function()
+      require("nvim-treesitter-textobjects").setup({
+        select = {
+          lookahead = true,
         },
-        highlight = {
-          enable = true,
-        },
-        indent = {
-          enable = true,
-        },
-        incremental_selection = {
-          enable = true,
-          keymaps = {
-            init_selection = "<C-space>",
-            node_incremental = "<C-space>",
-            scope_incremental = false,
-            node_decremental = "<bs>",
-          },
-        },
-        textobjects = {
-          select = {
-            enable = true,
-            lookahead = true,
-            keymaps = {
-              ["af"] = "@function.outer",
-              ["if"] = "@function.inner",
-              ["ac"] = "@class.outer",
-              ["ic"] = "@class.inner",
-              ["aa"] = "@parameter.outer",
-              ["ia"] = "@parameter.inner",
-            },
-          },
-          move = {
-            enable = true,
-            set_jumps = true,
-            goto_next_start = {
-              ["]f"] = "@function.outer",
-              ["]c"] = "@class.outer",
-              ["]a"] = "@parameter.inner",
-            },
-            goto_next_end = {
-              ["]F"] = "@function.outer",
-              ["]C"] = "@class.outer",
-            },
-            goto_previous_start = {
-              ["[f"] = "@function.outer",
-              ["[c"] = "@class.outer",
-              ["[a"] = "@parameter.inner",
-            },
-            goto_previous_end = {
-              ["[F"] = "@function.outer",
-              ["[C"] = "@class.outer",
-            },
-          },
-          swap = {
-            enable = true,
-            swap_next = {
-              ["<leader>a"] = "@parameter.inner",
-            },
-            swap_previous = {
-              ["<leader>A"] = "@parameter.inner",
-            },
-          },
+        move = {
+          set_jumps = true,
         },
       })
+
+      local select = require("nvim-treesitter-textobjects.select")
+      local move = require("nvim-treesitter-textobjects.move")
+      local swap = require("nvim-treesitter-textobjects.swap")
+
+      -- select
+      vim.keymap.set({ "x", "o" }, "af", function() select.select_textobject("@function.outer") end)
+      vim.keymap.set({ "x", "o" }, "if", function() select.select_textobject("@function.inner") end)
+      vim.keymap.set({ "x", "o" }, "ac", function() select.select_textobject("@class.outer") end)
+      vim.keymap.set({ "x", "o" }, "ic", function() select.select_textobject("@class.inner") end)
+      vim.keymap.set({ "x", "o" }, "aa", function() select.select_textobject("@parameter.outer") end)
+      vim.keymap.set({ "x", "o" }, "ia", function() select.select_textobject("@parameter.inner") end)
+
+      -- move
+      vim.keymap.set({ "n", "x", "o" }, "]f", function() move.goto_next_start("@function.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "]c", function() move.goto_next_start("@class.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "]a", function() move.goto_next_start("@parameter.inner") end)
+      vim.keymap.set({ "n", "x", "o" }, "]F", function() move.goto_next_end("@function.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "]C", function() move.goto_next_end("@class.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "[f", function() move.goto_previous_start("@function.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "[c", function() move.goto_previous_start("@class.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "[a", function() move.goto_previous_start("@parameter.inner") end)
+      vim.keymap.set({ "n", "x", "o" }, "[F", function() move.goto_previous_end("@function.outer") end)
+      vim.keymap.set({ "n", "x", "o" }, "[C", function() move.goto_previous_end("@class.outer") end)
+
+      -- swap
+      vim.keymap.set("n", "<leader>a", function() swap.swap_next("@parameter.inner") end)
+      vim.keymap.set("n", "<leader>A", function() swap.swap_previous("@parameter.inner") end)
     end,
   },
 }


### PR DESCRIPTION
## Summary
- `require("nvim-treesitter.configs")` モジュールが削除されたため新APIに移行
- `require("nvim-treesitter").install()` でパーサーインストール、`vim.treesitter.start()` でハイライト有効化
- textobjects を独立プラグインとして設定し、`vim.keymap.set` で明示的にキーマップ定義
- `markdown_inline` パーサーを追加

## Test plan
- [ ] Neovim でマークダウンファイルを開いてエラーが出ないことを確認
- [ ] シンタックスハイライトが正常に動作すること
- [ ] textobjects のキーマップ (`vaf`, `vif`, `]f`, `[f`, `<leader>a` 等) が動作すること
- [ ] `:checkhealth nvim-treesitter` でエラーがないこと