### PR TITLE
chore: add gitleaks pre-commit hook for secret detection

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,7 @@
+[extend]
+useDefault = true
+
+[allowlist]
+paths = [
+  '''\.tmpl$''',
+]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,11 @@ repos:
         args: ["--check"]
         files: \.lua$
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.0
+    hooks:
+      - id: gitleaks
+
   - repo: local
     hooks:
       - id: chezmoi-template-check


### PR DESCRIPTION
## Summary

- `.pre-commit-config.yaml` に gitleaks フックを追加し、シークレットの誤コミットを防止
- `.gitleaks.toml` を作成し、chezmoi テンプレートファイル (`.tmpl`) を許可リストに追加

## Background

このリポジトリは公開されており、今後 Obsidian vault パスや Prometheus URL 等の個人設定をテンプレートで管理する予定 (#61, #62)。その前にシークレット漏洩防止のガードを入れる。

## Test plan

- [x] `pre-commit run gitleaks --all-files` が Passed
- [x] 既存の全ファイルに対してシークレット検知が正常に動作することを確認

Closes #63