### PR TITLE
feat(git): add global gitleaks hook via core.hooksPath

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -9,7 +9,7 @@
 [core]
   editor = nvim
   autocrlf = input
-  hooksPath = ~/.config/git/hooks
+  hooksPath = {{ .chezmoi.homeDir }}/.config/git/hooks
 [init]
   defaultBranch = main
 [push]

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -9,6 +9,7 @@
 [core]
   editor = nvim
   autocrlf = input
+  hooksPath = ~/.config/git/hooks
 [init]
   defaultBranch = main
 [push]

--- a/private_dot_config/git/hooks/executable_pre-commit
+++ b/private_dot_config/git/hooks/executable_pre-commit
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Global pre-commit hook: runs gitleaks + project-local hooks
+
+# --- gitleaks ---
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks git --pre-commit --staged --no-banner
+  if [ $? -ne 0 ]; then
+    echo "gitleaks: secrets detected. Commit aborted."
+    exit 1
+  fi
+else
+  echo "warning: gitleaks not installed, skipping secret scan"
+fi
+
+# --- project-local pre-commit hook ---
+# If the project uses pre-commit framework, delegate to it
+if [ -f .pre-commit-config.yaml ] && command -v pre-commit >/dev/null 2>&1; then
+  pre-commit run --hook-stage pre-commit
+  exit $?
+fi
+
+# If project has its own .git/hooks/pre-commit (not this global one), run it
+LOCAL_HOOK="$(git rev-parse --git-dir)/hooks/pre-commit"
+if [ -f "$LOCAL_HOOK" ] && [ "$LOCAL_HOOK" != "$0" ]; then
+  "$LOCAL_HOOK"
+  exit $?
+fi

--- a/private_dot_config/git/hooks/executable_pre-commit
+++ b/private_dot_config/git/hooks/executable_pre-commit
@@ -1,10 +1,11 @@
 #!/bin/sh
 # Global pre-commit hook: runs gitleaks + project-local hooks
 
+GLOBAL_HOOK="$HOME/.config/git/hooks/pre-commit"
+
 # --- gitleaks ---
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks git --pre-commit --staged --no-banner
-  if [ $? -ne 0 ]; then
+  if ! gitleaks git --pre-commit --staged --no-banner; then
     echo "gitleaks: secrets detected. Commit aborted."
     exit 1
   fi
@@ -21,7 +22,7 @@ fi
 
 # If project has its own .git/hooks/pre-commit (not this global one), run it
 LOCAL_HOOK="$(git rev-parse --git-dir)/hooks/pre-commit"
-if [ -f "$LOCAL_HOOK" ] && [ "$LOCAL_HOOK" != "$0" ]; then
+if [ -f "$LOCAL_HOOK" ] && [ "$(readlink -f "$LOCAL_HOOK")" != "$(readlink -f "$GLOBAL_HOOK")" ]; then
   "$LOCAL_HOOK"
   exit $?
 fi


### PR DESCRIPTION
## Summary

- `~/.config/git/hooks/pre-commit` にグローバル pre-commit hook を追加
  - gitleaks がインストール済みなら全リポジトリでシークレットスキャンを実行
  - 未インストール時は警告のみでスキップ
- プロジェクトローカルの hook との共存をサポート
  - `.pre-commit-config.yaml` + `pre-commit` がある場合はそちらに委譲
  - `.git/hooks/pre-commit` がある場合もそちらを実行
- `~/.gitconfig` に `core.hooksPath = ~/.config/git/hooks` を追加

## Test plan

- [ ] `chezmoi apply` 後、gitleaks未導入リポジトリで警告が出ることを確認
- [ ] gitleaks導入済みリポジトリでスキャンが実行されることを確認
- [ ] `.pre-commit-config.yaml` があるリポジトリ（このリポジトリ）でpre-commitに委譲されることを確認

Closes #65