### PR TITLE
feat(claude): add Obsidian logging hook for tool usage

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -67,7 +67,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "~/.local/bin/claude-log-to-obsidian.sh",
+            "command": "$HOME/.local/bin/claude-log-to-obsidian.sh",
             "timeout": 5
           }
         ]

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -59,5 +59,19 @@
     "gopls-lsp@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true
   },
-  "preferredNotifChannel": "auto"
+  "preferredNotifChannel": "auto",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.local/bin/claude-log-to-obsidian.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/dot_local/bin/executable_claude-log-to-obsidian.sh.tmpl
+++ b/dot_local/bin/executable_claude-log-to-obsidian.sh.tmpl
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Log Claude Code tool usage to Obsidian daily note
+# Called by Claude Code hooks via stdin (JSON)
+
+VAULT_PATH="{{ .obsidian_vault_path }}"
+
+# Skip if vault path is not configured or does not exist
+if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
+  exit 0
+fi
+
+DAILY_DIR="$VAULT_PATH/daily"
+TODAY="$(date +%Y-%m-%d)"
+DAILY_NOTE="$DAILY_DIR/$TODAY.md"
+TIMESTAMP="$(date +%H:%M:%S)"
+
+# Read JSON from stdin
+INPUT="$(cat)"
+
+TOOL_NAME="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty')"
+CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty')"
+PROJECT="$(basename "$CWD")"
+
+# Skip if no tool name
+if [ -z "$TOOL_NAME" ]; then
+  exit 0
+fi
+
+# Create daily directory if needed
+mkdir -p "$DAILY_DIR"
+
+# Create daily note with header if it doesn't exist
+if [ ! -f "$DAILY_NOTE" ]; then
+  printf '# %s\n\n' "$TODAY" > "$DAILY_NOTE"
+fi
+
+# Append log entry
+printf '- `%s` **%s** | %s | %s\n' "$TIMESTAMP" "$TOOL_NAME" "$PROJECT" "$CWD" >> "$DAILY_NOTE"
+
+exit 0

--- a/dot_local/bin/executable_claude-log-to-obsidian.sh.tmpl
+++ b/dot_local/bin/executable_claude-log-to-obsidian.sh.tmpl
@@ -2,10 +2,15 @@
 # Log Claude Code tool usage to Obsidian daily note
 # Called by Claude Code hooks via stdin (JSON)
 
-VAULT_PATH="{{ .obsidian_vault_path }}"
+VAULT_PATH="{{ if hasKey . "obsidian_vault_path" }}{{ .obsidian_vault_path }}{{ end }}"
 
 # Skip if vault path is not configured or does not exist
 if [ -z "$VAULT_PATH" ] || [ ! -d "$VAULT_PATH" ]; then
+  exit 0
+fi
+
+# Require jq for JSON parsing
+if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Claude Code の `PostToolUse` hook を追加し、ツール使用ログを Obsidian daily note に出力
- ログスクリプト `~/.local/bin/claude-log-to-obsidian.sh` を chezmoi テンプレートで管理
  - Obsidian vault パスは `{{ .obsidian_vault_path }}` テンプレート変数で注入（ハードコードなし）
  - vault パス未設定 or ディレクトリ不在時はサイレントスキップ
- ログフォーマット: `- HH:MM:SS **ToolName** | project | cwd`
- daily note は `$VAULT/daily/YYYY-MM-DD.md` に出力

## Setup

`~/.config/chezmoi/chezmoi.toml` にテンプレート変数を追加:

```toml
[data]
    obsidian_vault_path = "/path/to/your/obsidian/vault"
```

## Test plan

- [ ] `chezmoi apply` 後、スクリプトが `~/.local/bin/` に配置されることを確認
- [ ] vault パス設定済みの状態で Claude Code 使用時にdaily noteにログが追記されることを確認
- [ ] vault パス未設定の場合にエラーなくスキップすることを確認

Closes #61