### PR TITLE
fix(nvim): add version guards for plugins requiring newer Neovim

### DIFF
--- a/.github/workflows/chezmoi-check.yml
+++ b/.github/workflows/chezmoi-check.yml
@@ -70,15 +70,24 @@ jobs:
   nvim-health:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        nvim-version: [v0.11.5, stable, nightly]
+        include:
+          - nvim-version: nightly
+            continue-on-error: true
+    continue-on-error: ${{ matrix.continue-on-error || false }}
+    name: nvim-health (${{ matrix.nvim-version }})
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Neovim (stable PPA)
-        run: |
-          sudo add-apt-repository -y ppa:neovim-ppa/stable
-          sudo apt-get update
-          sudo apt-get install -y neovim
+      - name: Install Neovim (${{ matrix.nvim-version }})
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.nvim-version }}
 
       - name: Install chezmoi and apply dotfiles (skip scripts)
         env:

--- a/private_dot_config/nvim/lua/edgissa/plugins/lsp/lspconfig.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/lsp/lspconfig.lua
@@ -3,6 +3,7 @@
 -- LSP client implementation is provided by Neovim itself.
 return {
   "neovim/nvim-lspconfig",
+  cond = vim.fn.has("nvim-0.11") == 1,
   event = { "BufReadPre", "BufNewFile" }, -- Load on buffer read or new file
   dependencies = {
     "williamboman/mason.nvim", -- LSP server installer

--- a/private_dot_config/nvim/lua/edgissa/plugins/lsp/mason.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/lsp/mason.lua
@@ -1,5 +1,6 @@
 return {
   "williamboman/mason.nvim",
+  cond = vim.fn.has("nvim-0.11") == 1,
   dependencies = {
     "williamboman/mason-lspconfig.nvim",
     "WhoIsSethDaniel/mason-tool-installer.nvim",
@@ -24,6 +25,7 @@ return {
 
     -- Setup LSP servers and tools
     mason_lspconfig.setup({
+      automatic_enable = vim.fn.has("nvim-0.11") == 1,
       ensure_installed = {
         "bashls",
         "cssls",

--- a/private_dot_config/nvim/lua/edgissa/plugins/lsp/mason.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/lsp/mason.lua
@@ -25,7 +25,7 @@ return {
 
     -- Setup LSP servers and tools
     mason_lspconfig.setup({
-      automatic_enable = vim.fn.has("nvim-0.11") == 1,
+      automatic_enable = true,
       ensure_installed = {
         "bashls",
         "cssls",

--- a/private_dot_config/nvim/lua/edgissa/plugins/treesitter.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/treesitter.lua
@@ -21,6 +21,7 @@ return {
     "nvim-treesitter/nvim-treesitter",
     lazy = false,
     build = ":TSUpdate",
+    cond = vim.fn.has("nvim-0.10") == 1,
     config = function()
       local ts = require("nvim-treesitter")
       local installed = ts.get_installed()
@@ -51,6 +52,7 @@ return {
   {
     "nvim-treesitter/nvim-treesitter-textobjects",
     lazy = false,
+    cond = vim.fn.has("nvim-0.10") == 1,
     dependencies = { "nvim-treesitter/nvim-treesitter" },
     config = function()
       require("nvim-treesitter-textobjects").setup({


### PR DESCRIPTION
## Summary
- `vi` (Neovim 0.9.5) と `nvim` (0.11.5) が混在する環境で、古い方で起動するとプラグインがクラッシュする問題を修正
- nvim-treesitter / textobjects: `cond = vim.fn.has("nvim-0.10") == 1` を追加 (`vim.fs.joinpath` が 0.10+ で追加)
- mason.nvim / lspconfig: `cond = vim.fn.has("nvim-0.11") == 1` を追加 (`vim.lsp.config`, `vim.lsp.enable` が 0.11+ で追加)
- mason-lspconfig の `automatic_enable` を明示的に設定 (v2 でデフォルト `true` に変更されたため)

## Test plan
- [x] `nvim --headless -c 'q'` でエラーなく起動確認 (0.11.5)
- [x] `vi` (0.9.5) で起動してプラグインエラーが出ないことを確認