### PR TITLE
fix(install): add build-deps before cargo with multi-OS support

### DIFF
--- a/run_once_before_install-build-deps.sh.tmpl
+++ b/run_once_before_install-build-deps.sh.tmpl
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[install] $*"; }
+
+if [ -n "${CI:-}" ]; then
+  log "CI environment detected. Skipping build dependencies installation."
+  exit 0
+fi
+
+{{ if eq .chezmoi.os "linux" }}
+log "Installing build dependencies for Linux"
+
+if [ -f /etc/os-release ]; then
+  . /etc/os-release
+  case "${ID:-}" in
+    ubuntu|debian|pop|linuxmint)
+      sudo apt update
+      sudo apt install -y build-essential libssl-dev pkg-config cmake
+      ;;
+    fedora)
+      sudo dnf groupinstall -y "Development Tools"
+      sudo dnf install -y openssl-devel pkg-config cmake
+      ;;
+    rhel|centos|rocky|alma)
+      sudo dnf groupinstall -y "Development Tools"
+      sudo dnf install -y openssl-devel pkg-config cmake
+      ;;
+    arch|manjaro|endeavouros)
+      sudo pacman -Syu --noconfirm --needed base-devel openssl pkg-config cmake
+      ;;
+    # opensuse-leap, opensuse-tumbleweed, etc.
+    opensuse*|sles)
+      sudo zypper install -y -t pattern devel_basis
+      sudo zypper install -y libopenssl-devel pkg-config cmake
+      ;;
+    *)
+      log "WARNING: Unsupported distro '${ID:-unknown}'. Install a C compiler, OpenSSL dev headers, pkg-config, and cmake manually."
+      exit 1
+      ;;
+  esac
+else
+  log "WARNING: /etc/os-release not found. Cannot detect distro."
+  exit 1
+fi
+{{ else if eq .chezmoi.os "darwin" }}
+# macOS: Xcode CLT provides cc (requires GUI dialog for installation)
+if ! xcode-select -p >/dev/null 2>&1; then
+  log "Installing Xcode Command Line Tools..."
+  xcode-select --install
+  log "Please complete the Xcode CLT installation dialog and re-run chezmoi apply"
+  exit 1
+fi
+{{ end }}

--- a/run_once_install-cargo.sh.tmpl
+++ b/run_once_install-cargo.sh.tmpl
@@ -9,6 +9,11 @@ if [ -n "${CI:-}" ]; then
   exit 0
 fi
 
+{{ if eq .chezmoi.os "darwin" }}
+log "macOS detected. Rust tools are installed via Homebrew. Skipping."
+exit 0
+{{ end }}
+
 # Rust toolchain
 if command -v cargo >/dev/null 2>&1; then
   log "cargo is already installed, skipping rustup"

--- a/run_once_install-cargo.sh.tmpl
+++ b/run_once_install-cargo.sh.tmpl
@@ -9,10 +9,11 @@ if [ -n "${CI:-}" ]; then
   exit 0
 fi
 
-{{ if eq .chezmoi.os "darwin" }}
-log "macOS detected. Rust tools are installed via Homebrew. Skipping."
-exit 0
-{{ end }}
+# macOS: Rust tools are installed via Homebrew
+if [ "$(uname -s)" = "Darwin" ]; then
+  log "macOS detected. Rust tools are installed via Homebrew. Skipping."
+  exit 0
+fi
 
 # Rust toolchain
 if command -v cargo >/dev/null 2>&1; then

--- a/run_once_install-linux-packages.sh.tmpl
+++ b/run_once_install-linux-packages.sh.tmpl
@@ -13,13 +13,10 @@ log "Installing system packages and Go tools"
 
 sudo apt update
 
-# Development tools
+# Utility tools
 if ! command -v htop >/dev/null 2>&1; then
-  log "Installing development tools..."
-  sudo apt install -y htop build-essential libssl-dev pkg-config cmake
-
-  # x11
-  sudo apt install -y xclip
+  log "Installing utility tools..."
+  sudo apt install -y htop xclip
 fi
 
 # Install ripgrep for better grep performance (needed by Neovim)


### PR DESCRIPTION
## Summary
- `run_once_before_install-build-deps.sh.tmpl` を新規作成し、Rust/cargo ビルドに必要なシステム依存パッケージ（C compiler, OpenSSL headers, pkg-config, cmake）を事前にインストール
- chezmoi の `run_once_before_` プレフィックスにより、既存の `run_once_` スクリプトより先に実行される
- マルチOS対応: Ubuntu/Debian, Fedora/RHEL, Arch, openSUSE, macOS (Xcode CLT)
- `run_once_install-linux-packages.sh.tmpl` から重複するビルド依存パッケージを削除
- `run_once_install-cargo.sh.tmpl` に macOS スキップガードを追加（Homebrew で同等ツールをインストール済み）

Closes #71

## Test plan
- [x] `chezmoi execute-template` で各テンプレートが正しくレンダリングされることを確認
- [x] Ubuntu 環境で `chezmoi apply` を実行し、build-deps → cargo の順序で実行されることを確認
- [x] macOS 環境で cargo スクリプトがスキップされることを確認