### PR TITLE
feat(claude): add cross-platform permission notification hook

### DIFF
--- a/dot_claude/hooks/executable_permission-notify.sh
+++ b/dot_claude/hooks/executable_permission-notify.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+title="Claude Code"
+message="Permission required"
+
+# Parse JSON from stdin if jq is available
+if command -v jq >/dev/null 2>&1; then
+  payload="$(cat)"
+  title="$(printf '%s' "$payload" | jq -r '.title // "Claude Code"')"
+  message="$(printf '%s' "$payload" | jq -r '.message // "Permission required"')"
+fi
+
+case "$(uname -s)" in
+  Darwin)
+    osascript -e "display notification \"$message\" with title \"$title\" sound name \"Glass\""
+    ;;
+  Linux)
+    notify-send -u critical "$title" "$message" 2>/dev/null || true
+    if command -v paplay >/dev/null 2>&1 && [ -f /usr/share/sounds/freedesktop/stereo/bell.oga ]; then
+      paplay /usr/share/sounds/freedesktop/stereo/bell.oga &
+    fi
+    ;;
+  *)
+    printf '\a' >/dev/tty 2>/dev/null || true
+    ;;
+esac

--- a/dot_claude/settings.local.json
+++ b/dot_claude/settings.local.json
@@ -2,22 +2,11 @@
   "hooks": {
     "Notification": [
       {
-        "matcher": "",
+        "matcher": "permission_prompt",
         "hooks": [
           {
             "type": "command",
-            "command": "notify-send -u normal -i dialog-question 'Claude Code' 'Waiting for your input' 2>/dev/null; spd-say -l ja '入力待ちです' 2>/dev/null &"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "notify-send -u low -i dialog-information 'Claude Code' 'Response complete' 2>/dev/null; spd-say -l ja '完了しました' 2>/dev/null &"
+            "command": "~/.claude/hooks/permission-notify.sh"
           }
         ]
       }

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -44,10 +44,21 @@ set -g focus-events on
 # -----------------------
 # Bell Config (for Claude Code notifications)
 # -----------------------
-set -g visual-bell off
-set -g bell-action any
-setw -g monitor-bell on
-set -g window-status-bell-style 'fg=red,bg=black,bold,blink'
+# activity
+set -g monitor-activity on
+set -g visual-activity both
+set -g activity-action other
+set -g window-status-activity-style 'reverse'
+
+# bell
+set -g monitor-bell on
+set -g visual-bell both
+set -g bell-action other
+set -g window-status-bell-style 'reverse'
+
+set -g monitor-silence 180
+set -g silence-action other
+set -g visual-silence on
 
 # -----------------------
 # Pane Style

--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -1,22 +1,22 @@
-local wezterm = require 'wezterm'
+local wezterm = require("wezterm")
 local config = wezterm.config_builder()
 
-config.font = wezterm.font 'UDEV Gothic NF'
+config.font = wezterm.font("UDEV Gothic NF")
 config.font_size = 12.0
-config.color_scheme = 'Tokyo Night'
-config.term = 'xterm-256color'
-config.window_decorations = 'RESIZE'
+config.color_scheme = "Tokyo Night"
+config.term = "xterm-256color"
+config.window_decorations = "RESIZE"
 config.enable_tab_bar = false
 config.window_background_opacity = 0.95
 config.scrollback_lines = 200
 config.use_ime = true
-config.xim_im_name = 'fcitx'
-config.ime_preedit_rendering = 'Builtin'
+config.xim_im_name = "fcitx"
+config.ime_preedit_rendering = "Builtin"
 
 config.keys = {
   {
-    key = ' ',
-    mods = 'CTRL',
+    key = " ",
+    mods = "CTRL",
     action = wezterm.action.DisableDefaultAssignment,
   },
 }

--- a/run_once_install-linux-packages.sh.tmpl
+++ b/run_once_install-linux-packages.sh.tmpl
@@ -42,6 +42,12 @@ if ! command -v tmux >/dev/null 2>&1; then
   sudo apt install -y tmux
 fi
 
+# Notification sound support for Claude Code hooks
+if ! command -v paplay >/dev/null 2>&1; then
+  log "Installing pulseaudio-utils (paplay)..."
+  sudo apt install -y pulseaudio-utils
+fi
+
 if ! command -v go >/dev/null 2>&1; then
   log "go command still not found; PATH is: $PATH"
   exit 1


### PR DESCRIPTION
## Summary
- Claude Code の permission_prompt 時にデスクトップ通知＋音を鳴らすフックを追加
- macOS (osascript + Glass sound) / Linux (notify-send + paplay) の両対応
- Linux 依存パッケージ (pulseaudio-utils) をインストールスクリプトに追加

## Changes
- `dot_claude/hooks/executable_permission-notify.sh` — 新規：クロスプラットフォーム通知スクリプト
- `dot_claude/settings.local.json` — matcher を `permission_prompt` に限定、外部スクリプト参照に変更
- `run_once_install-linux-packages.sh.tmpl` — `pulseaudio-utils` を依存に追加

## Test plan
- [x] Ubuntu で通知と音が出ることを確認済み
- [ ] macOS で通知と音が出ることを確認