### PR TITLE
feat(nvim,zsh): improve Markdown experience with markview.nvim and glow

### DIFF
--- a/docs/superpowers/specs/2026-03-22-markview-nvim-design.md
+++ b/docs/superpowers/specs/2026-03-22-markview-nvim-design.md
@@ -1,0 +1,66 @@
+# markview.nvim Integration Design
+
+## Goal
+
+Add markview.nvim to the Neovim configuration to improve Markdown readability within the editor. Primary use case: reading Claude-generated Markdown (CLAUDE.md, chat outputs, documentation).
+
+## Design Decisions
+
+- **Plugin**: `OXY2DEV/markview.nvim` — actively maintained, supports Markdown/HTML/LaTeX/Typst
+- **Approach**: Minimal configuration, rely on plugin defaults
+- **Insert mode**: Hybrid mode — show raw Markdown on the current line while editing, render everything else
+- **Lazy loading**: `lazy = false` per plugin recommendation (plugin handles its own lazy loading internally)
+- **Dependencies**: `nvim-web-devicons` already available via neo-tree
+
+## Implementation
+
+### New file: `private_dot_config/nvim/lua/edgissa/plugins/markview.lua`
+
+```lua
+return {
+  "OXY2DEV/markview.nvim",
+  lazy = false,
+  cond = vim.fn.has("nvim-0.10") == 1,
+  config = function()
+    require("markview").setup({
+      preview = {
+        modes = { "n", "no", "c" },
+        hybrid_modes = { "n" },
+        linewise_hybrid_mode = true,
+      },
+    })
+  end,
+}
+```
+
+### Configuration rationale
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| `lazy` | `false` | Plugin docs warn against lazy-loading; it self-manages |
+| `cond` | `vim.fn.has("nvim-0.10") == 1` | Requires Neovim >= 0.10; matches treesitter.lua pattern |
+| `modes` | `{ "n", "no", "c" }` | Render in normal/operator-pending/command modes (default) |
+| `hybrid_modes` | `{ "n" }` | In normal mode, show raw source on cursor line for easy reading of actual syntax |
+| `linewise_hybrid_mode` | `true` | Only un-render the current line, not the whole block |
+
+Insert mode is NOT in `modes`, so entering insert mode automatically shows raw Markdown — matching user preference (A).
+
+### No changes needed
+
+- TreeSitter `markdown` and `markdown_inline` parsers: already installed
+- `nvim-web-devicons`: already a dependency of neo-tree (markview.nvim's default `icon_provider` is `"internal"`, so it works without devicons too)
+- Colorscheme: markview.nvim auto-generates highlight groups from the active colorscheme (catppuccin mocha)
+
+## Verification
+
+1. `chezmoi diff` — confirm only the new file is added
+2. `chezmoi apply` — apply to home directory
+3. Open a `.md` file in Neovim — confirm headings, code blocks, tables render
+4. Enter insert mode — confirm raw Markdown is shown
+5. `:Markview` — confirm toggle works
+
+## Scope
+
+- Single new file addition
+- No changes to existing configuration
+- No new dependencies to install

--- a/private_dot_config/nvim/lua/edgissa/plugins/markview.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/markview.lua
@@ -1,0 +1,14 @@
+return {
+  "OXY2DEV/markview.nvim",
+  lazy = false,
+  cond = vim.fn.has("nvim-0.10") == 1,
+  config = function()
+    require("markview").setup({
+      preview = {
+        modes = { "n", "no", "c" },
+        hybrid_modes = { "n" },
+        linewise_hybrid_mode = true,
+      },
+    })
+  end,
+}

--- a/private_dot_config/zsh/functions.zsh
+++ b/private_dot_config/zsh/functions.zsh
@@ -38,6 +38,15 @@ function gpr() {
   [ -n "$pr" ] && gh pr checkout "$pr"
 }
 
+# Browse and preview Markdown files with fzf + glow
+function mdp() {
+  local dir="${1:-.}"
+  local file
+  file=$(find "$dir" -name '*.md' -not -path '*/.git/*' -not -path '*/node_modules/*' 2>/dev/null | \
+    fzf --preview 'glow -s dark -w $FZF_PREVIEW_COLUMNS {}' --preview-window=right:60%)
+  [ -n "$file" ] && glow -p "$file"
+}
+
 # Browse git stash entries with fzf
 function gst() {
   local stash

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -31,5 +31,6 @@ brew install \
   neovim \
   ripgrep \
   fd \
-  bat
+  bat \
+  glow
 {{ end }}

--- a/run_once_install-linux-packages.sh.tmpl
+++ b/run_once_install-linux-packages.sh.tmpl
@@ -63,4 +63,9 @@ if ! command -v ghq >/dev/null 2>&1; then
   log "Installing ghq..."
   go install github.com/x-motemen/ghq@latest
 fi
+
+if ! command -v glow >/dev/null 2>&1; then
+  log "Installing glow..."
+  go install github.com/charmbracelet/glow@latest
+fi
 {{ end }}


### PR DESCRIPTION
## Summary

- markview.nvim プラグインを追加し、Neovim 内での Markdown 装飾表示を実現
- glow をインストールスクリプトに追加（macOS: brew, Linux: go install）
- `mdp()` 関数を追加し、fzf + glow でターミナルから Markdown をブラウズ・プレビュー

## Changes

### markview.nvim (Neovim)
- ノーマルモードではカーソル行のみ raw 表示（hybrid mode）、挿入モードでは全体を raw 表示
- `lazy = false` / `cond = vim.fn.has("nvim-0.10") == 1`

### glow (Terminal)
- `run_once_install-homebrew.sh.tmpl`: brew install に glow を追加
- `run_once_install-linux-packages.sh.tmpl`: go install で glow を追加
- `functions.zsh`: `mdp()` 関数追加 — fzf でファイル選択、glow でプレビュー・表示

## Test plan

- [ ] Neovim で `.md` ファイルを開いて装飾表示されることを確認
- [ ] 挿入モードで raw Markdown に切り替わることを確認
- [ ] `mdp` コマンドで Markdown ファイルをプレビューできることを確認
- [ ] `glow README.md` が動作することを確認