### PR TITLE
fix(install): add wl-clipboard for tmux copy-paste on Wayland

### DIFF
--- a/run_once_install-linux-packages.sh.tmpl
+++ b/run_once_install-linux-packages.sh.tmpl
@@ -19,6 +19,12 @@ if ! command -v htop >/dev/null 2>&1; then
   sudo apt install -y htop xclip
 fi
 
+# Wayland clipboard support (required for tmux-yank on Wayland sessions)
+if ! command -v wl-copy >/dev/null 2>&1; then
+  log "Installing wl-clipboard..."
+  sudo apt install -y wl-clipboard
+fi
+
 # Install ripgrep for better grep performance (needed by Neovim)
 if ! command -v rg >/dev/null 2>&1; then
   log "Installing ripgrep..."


### PR DESCRIPTION
## Summary
- Wayland セッションで `tmux-yank` が `wl-copy` を優先的に呼び出すが、`wl-clipboard` が未インストールだとコピーが機能しない問題を修正
- `xclip` のみだと XWayland 経由のクリップボードになり Wayland 側と同期しないため、`run_once_install-linux-packages.sh.tmpl` に `wl-clipboard` の自動インストールを追加

## Test plan
- [ ] `sudo apt install -y wl-clipboard` 実行後、`tmux source-file ~/.tmux.conf`
- [ ] tmux コピーモード (`prefix` + `[` → `v` 選択 → `y`) でシステムクリップボードへコピーできることを確認
- [ ] マウス選択でのコピーが Wayland 側へ反映されることを確認
- [ ] `chezmoi apply` で `run_once_` スクリプトが再実行されることを確認 (ハッシュ変化により再実行)