### PR TITLE
fix(tmux): enable clipboard by auto-installing TPM plugins

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -65,12 +65,18 @@ set -g pane-border-style 'fg=colour238'
 set -g pane-active-border-style 'fg=colour117,bold'
 
 # -----------------------
+# Clipboard (OSC52)
+# -----------------------
+set -g set-clipboard on
+set -as terminal-features ',xterm*:clipboard'
+set -as terminal-features ',wezterm:clipboard'
+
+# -----------------------
 # Copy Mode
 # -----------------------
 setw -g mode-keys vi
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-selection-and-cancel
-bind -T copy-mode-vi Enter send-keys -X copy-selection-and-cancel
+# y / Enter / MouseDragEnd1Pane are bound by tmux-yank (OS-aware: wl-copy / xclip / pbcopy)
 bind -T copy-mode C-u send-keys -X page-up
 bind -T copy-mode C-d send-keys -X page-down
 

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -69,7 +69,6 @@ set -g pane-active-border-style 'fg=colour117,bold'
 # -----------------------
 set -g set-clipboard on
 set -as terminal-features ',xterm*:clipboard'
-set -as terminal-features ',wezterm:clipboard'
 
 # -----------------------
 # Copy Mode

--- a/run_onchange_install-tmux-plugins.sh.tmpl
+++ b/run_onchange_install-tmux-plugins.sh.tmpl
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Re-runs whenever dot_tmux.conf (which holds the @plugin declarations) changes.
 # tmux.conf hash: {{ include "dot_tmux.conf" | sha256sum }}
 
 log() { echo "[install] $*"; }
@@ -17,8 +18,8 @@ fi
 
 TPM_DIR="${HOME}/.tmux/plugins/tpm"
 if [ ! -x "${TPM_DIR}/bin/install_plugins" ]; then
-  log "TPM not found at ${TPM_DIR}. .chezmoiexternal.toml should provide it."
-  exit 0
+  log "ERROR: TPM not found at ${TPM_DIR}. .chezmoiexternal.toml should clone it before this script runs."
+  exit 1
 fi
 
 log "Installing tmux plugins via TPM..."

--- a/run_onchange_install-tmux-plugins.sh.tmpl
+++ b/run_onchange_install-tmux-plugins.sh.tmpl
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# tmux.conf hash: {{ include "dot_tmux.conf" | sha256sum }}
+
+log() { echo "[install] $*"; }
+
+if [ -n "${CI:-}" ]; then
+  log "CI environment detected. Skipping tmux plugin installation."
+  exit 0
+fi
+
+if ! command -v tmux >/dev/null 2>&1; then
+  log "tmux not found. Skipping plugin installation."
+  exit 0
+fi
+
+TPM_DIR="${HOME}/.tmux/plugins/tpm"
+if [ ! -x "${TPM_DIR}/bin/install_plugins" ]; then
+  log "TPM not found at ${TPM_DIR}. .chezmoiexternal.toml should provide it."
+  exit 0
+fi
+
+log "Installing tmux plugins via TPM..."
+"${TPM_DIR}/bin/install_plugins"
+log "tmux plugins installed."


### PR DESCRIPTION
## Summary

- Add `run_onchange_install-tmux-plugins.sh.tmpl` so TPM plugins (tmux-yank, etc.) are installed non-interactively on `chezmoi apply`. Previously only TPM itself was cloned via `.chezmoiexternal.toml`, leaving plugins missing until the user manually pressed `prefix + I`.
- Drop the self-defined `copy-mode-vi` `y`/`Enter` bindings in `dot_tmux.conf` so tmux-yank can install its OS-aware copy-pipe bindings (wl-copy / xclip / pbcopy).
- Enable OSC52 (`set-clipboard on` + `terminal-features ',xterm*:clipboard'`) as a fallback for terminals like WezTerm, useful when external clipboard tools are unavailable (e.g. SSH).

Closes the gap left by ffb0865 (which only added `wl-clipboard` to the install list).

## Test plan

- [x] `make lint` passes
- [x] `chezmoi diff` shows expected hunks
- [x] `chezmoi apply` runs the new script and `~/.tmux/plugins/` is fully populated (`tpm tmux-yank tmux-resurrect tmux-continuum tmux-mem-cpu-load tmux`)
- [x] After `tmux source ~/.tmux.conf`, `tmux list-keys -T copy-mode-vi` shows `y` bound to `copy-pipe-and-cancel wl-copy`
- [x] `tmux show-options -g set-clipboard` is `on`
- [ ] In tmux: `prefix + [` → `v` to select → `y` → paste into a non-WezTerm app (browser, etc.) succeeds