### PR TITLE
feat: MacBook セットアップ対応とツール追加

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -16,9 +16,18 @@
 {{ else -}}
 {{   $op_account = promptStringOnce . "op_account" "What is your 1Password account (e.g. my.1password.com, leave empty to skip)" -}}
 {{ end -}}
+{{ $useOnePasswordSSHAgent := false -}}
+{{ if env "CI" -}}
+{{   $useOnePasswordSSHAgent = false -}}
+{{ else if hasKey . "useOnePasswordSSHAgent" -}}
+{{   $useOnePasswordSSHAgent = .useOnePasswordSSHAgent -}}
+{{ else -}}
+{{   $useOnePasswordSSHAgent = promptBoolOnce . "useOnePasswordSSHAgent" "Use 1Password SSH Agent for GitHub?" false -}}
+{{ end -}}
 
 data:
   email: {{ $email | quote }}
   name: {{ $name | quote }}
   memo_dir: {{ $memo_dir | quote }}
   op_account: {{ $op_account | quote }}
+  useOnePasswordSSHAgent: {{ $useOnePasswordSSHAgent }}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,6 +1,7 @@
 # Repository-only files (not dotfiles)
 CLAUDE.md
 README.md
+Makefile
 docs/
 .pre-commit-config.yaml
 .stylua.toml

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -10,3 +10,8 @@ docs/
 .claude/.update.lock
 .claude/shell-snapshots/
 .claude/plugins/
+
+# 1Password SSH Agent: opt-out 時は ~/.ssh を一切管理しない（既存設定・空ディレクトリへ無影響）
+{{- if not (get . "useOnePasswordSSHAgent") }}
+.ssh
+{{- end }}

--- a/.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl
@@ -1,0 +1,26 @@
+{{ if get . "useOnePasswordSSHAgent" -}}
+#!/bin/sh
+# One-time notice after `chezmoi apply` when the 1Password SSH Agent is opted in.
+# Renders to nothing (and is not run) when useOnePasswordSSHAgent is false.
+set -eu
+
+{{ if eq .chezmoi.os "darwin" -}}
+sock="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+{{ else -}}
+sock="$HOME/.1password/agent.sock"
+{{ end -}}
+
+echo "==> 1Password SSH Agent (GitHub)"
+if [ -S "$sock" ]; then
+  echo "    SSH Agent socket found: $sock"
+  echo "    Verify your GitHub connection:"
+  echo "        ssh -T git@github.com"
+else
+  echo "    SSH Agent socket not found: $sock"
+  echo "    Enable it manually in the 1Password desktop app:"
+  echo "        1. Open the 1Password desktop app"
+  echo "        2. Open Settings > Developer"
+  echo "        3. Enable 'Use the SSH Agent'"
+  echo "        4. Verify: ssh -T git@github.com"
+fi
+{{ end -}}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ source ~/.zshenv
 
 > **macOS の注意**: ステップ 1 で Xcode Command Line Tools のインストールダイアログが表示されます。完了後に `chezmoi apply` を再実行してください。
 
+### SSH (1Password SSH Agent)
+
+新規端末では、この公開リポジトリを HTTPS のまま `chezmoi init --apply` できます。SSH 鍵をローカルへ展開する必要はありません。
+
+`chezmoi init` 時に `Use 1Password SSH Agent for GitHub?` を聞かれます。`yes` を選ぶと `~/.ssh/config` の `Host github.com` に 1Password SSH Agent のソケットを指す `IdentityAgent` が設定されます（既存設定があればマージされ、重複は作りません）。`no` を選んだ場合、既存の SSH 設定には一切手を加えません。
+
+opt-in 後は、1Password デスクトップアプリで **Settings > Developer > Use the SSH Agent** を有効化し、接続を確認します:
+
+```bash
+ssh -T git@github.com
+```
+
+秘密鍵は 1Password の SSH Agent ソケット経由で利用され、ローカルのファイルへは展開されません。
+
 ## Update
 
 ```bash

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,6 +1,10 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "cleanupPeriodDays": 60,
-  "includeCoAuthoredBy": false,
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "permissions": {
     "allow": [
       "Read(**)",
@@ -25,7 +29,11 @@
       "Bash(git merge:*)",
       "Bash(git rev-parse:*)",
       "Bash(git show:*)",
-      "Bash(gh pr:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh pr status:*)",
       "Bash(gh issue:*)",
       "Bash(gh run:*)",
       "Bash(gh api:*)",
@@ -78,9 +86,15 @@
       "Read(id_ed25519)",
       "Write(.env*)"
     ],
+    "ask": [
+      "Bash(gh pr create:*)",
+      "Bash(gh pr merge:*)"
+    ],
     "defaultMode": "plan"
   },
   "model": "opus",
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "high",
   "enableAllProjectMcpServers": true,
   "hooks": {
     "Notification": [
@@ -129,5 +143,10 @@
       }
     }
   },
-  "preferredNotifChannel": "auto"
+  "env": {
+    "CLAUDE_CODE_ENABLE_AUTO_MODE": "1"
+  },
+  "language": "japanese",
+  "preferredNotifChannel": "auto",
+  "editorMode": "vim"
 }

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -21,5 +21,3 @@ compinit -C
 [ -f ~/.config/zsh/aliases.zsh ] && source ~/.config/zsh/aliases.zsh
 [ -f ~/.config/zsh/plugins.zsh ] && source ~/.config/zsh/plugins.zsh
 [ -f ~/.config/zsh/functions.zsh ] && source ~/.config/zsh/functions.zsh
-
-. "$HOME/.local/bin/env"

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -21,3 +21,5 @@ compinit -C
 [ -f ~/.config/zsh/aliases.zsh ] && source ~/.config/zsh/aliases.zsh
 [ -f ~/.config/zsh/plugins.zsh ] && source ~/.config/zsh/plugins.zsh
 [ -f ~/.config/zsh/functions.zsh ] && source ~/.config/zsh/functions.zsh
+
+. "$HOME/.local/bin/env"

--- a/private_dot_config/nvim/lua/edgissa/core/options.lua
+++ b/private_dot_config/nvim/lua/edgissa/core/options.lua
@@ -3,6 +3,15 @@ local opt = vim.opt
 -- Disable optional providers to suppress warnings
 vim.g.loaded_perl_provider = 0
 vim.g.loaded_ruby_provider = 0
+-- Node provider is unused (no node rplugins) and Volta's global model
+-- doesn't satisfy nvim's detection; disable to silence the warning
+vim.g.loaded_node_provider = 0
+
+-- Point Neovim to the dedicated Python venv if it exists (macOS); falls back to system python3
+local nvim_py = vim.fn.expand("~/.local/share/neovim-python/bin/python")
+if vim.fn.executable(nvim_py) == 1 then
+  vim.g.python3_host_prog = nvim_py
+end
 
 -- Browse
 opt.number = true

--- a/private_dot_ssh/modify_private_config.tmpl
+++ b/private_dot_ssh/modify_private_config.tmpl
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Merge the 1Password SSH Agent socket into ~/.ssh/config under `Host github.com`.
+# chezmoi pipes the current file contents on stdin and uses our stdout as the new
+# contents. This only runs when `useOnePasswordSSHAgent` is true; otherwise the
+# target is ignored via .chezmoiignore, so existing SSH config is never touched.
+set -eu
+{{ if get . "useOnePasswordSSHAgent" -}}
+{{ if eq .chezmoi.os "darwin" -}}
+agent_line='    IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"'
+{{ else -}}
+agent_line='    IdentityAgent ~/.1password/agent.sock'
+{{ end -}}
+
+# shellcheck disable=SC2016
+awk -v agent_line="$agent_line" '
+function host_has_github(line,    rest, n, parts, i) {
+  rest = line
+  sub(/^[[:space:]]*[Hh]ost[[:space:]]+/, "", rest)
+  n = split(rest, parts, /[[:space:]]+/)
+  for (i = 1; i <= n; i++) {
+    if (parts[i] == "github.com") return 1
+  }
+  return 0
+}
+BEGIN { in_gh = 0; gh_seen = 0 }
+/^[[:space:]]*[Hh]ost[[:space:]]/ {
+  if (host_has_github($0)) {
+    in_gh = 1
+    gh_seen = 1
+    print
+    print agent_line
+    next
+  }
+  in_gh = 0
+}
+/^[[:space:]]*[Mm]atch[[:space:]]/ { in_gh = 0 }
+{
+  if (in_gh && $0 ~ /^[[:space:]]*IdentityAgent[[:space:]]/) next
+  print
+}
+END {
+  if (!gh_seen) {
+    print "Host github.com"
+    print agent_line
+  }
+}
+'
+{{ else -}}
+cat
+{{ end -}}

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -36,5 +36,6 @@ brew install \
   ripgrep \
   sheldon \
   starship \
-  tmux
+  tmux \
+  tree-sitter-cli
 {{ end }}

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -38,5 +38,6 @@ brew install \
   sheldon \
   starship \
   tmux \
-  tree-sitter-cli
+  tree-sitter-cli \
+  wget
 {{ end }}

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -21,16 +21,18 @@ fi
 
 # Core packages
 brew install \
+  atuin \
+  bat \
+  chezmoi  \
+  direnv \
   eza \
+  fd \
   fzf \
   ghq \
-  sheldon \
-  starship \
-  atuin \
-  direnv \
+  glow \
   neovim \
   ripgrep \
-  fd \
-  bat \
-  glow
+  sheldon \
+  starship \
+  tmux
 {{ end }}

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -28,7 +28,9 @@ brew install \
   eza \
   fd \
   fzf \
+  gh \
   ghq \
+  gitleaks \
   glow \
   neovim \
   ripgrep \

--- a/run_once_install-homebrew.sh.tmpl
+++ b/run_once_install-homebrew.sh.tmpl
@@ -32,6 +32,7 @@ brew install \
   ghq \
   gitleaks \
   glow \
+  go \
   neovim \
   ripgrep \
   sheldon \

--- a/run_once_install-python-tools.sh.tmpl
+++ b/run_once_install-python-tools.sh.tmpl
@@ -25,6 +25,12 @@ else
 fi
 
 {{ if eq .chezmoi.os "darwin" }}
+# uv-managed Python with python3/python shims on PATH (~/.local/bin, PATH先頭).
+# Mason's PyPI installer requires python3 >= 3.10, but macOS system python is 3.9.6.
+# darwin限定: Linuxはディストロのpython3(>=3.10)とapt pynvimを使うためshadowしない。
+log "Installing uv-managed Python 3.13 with default executables..."
+uv python install --default 3.13
+
 # Dedicated venv for Neovim Python provider (Homebrew python is externally-managed)
 NVIM_PY_VENV="$HOME/.local/share/neovim-python"
 if [ ! -x "$NVIM_PY_VENV/bin/python" ]; then

--- a/run_once_install-python-tools.sh.tmpl
+++ b/run_once_install-python-tools.sh.tmpl
@@ -23,3 +23,14 @@ else
   log "Installing uv..."
   curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
+
+{{ if eq .chezmoi.os "darwin" }}
+# Dedicated venv for Neovim Python provider (Homebrew python is externally-managed)
+NVIM_PY_VENV="$HOME/.local/share/neovim-python"
+if [ ! -x "$NVIM_PY_VENV/bin/python" ]; then
+  log "Creating Neovim Python venv at $NVIM_PY_VENV..."
+  uv venv "$NVIM_PY_VENV"
+fi
+log "Installing pynvim into Neovim venv..."
+uv pip install --python "$NVIM_PY_VENV/bin/python" pynvim
+{{ end }}

--- a/run_once_install-python-tools.sh.tmpl
+++ b/run_once_install-python-tools.sh.tmpl
@@ -24,6 +24,10 @@ else
   curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
+# uv installs to ~/.local/bin; ensure it is on PATH for the rest of this script
+# (this non-interactive shell has not sourced ~/.zshenv).
+export PATH="$HOME/.local/bin:$PATH"
+
 {{ if eq .chezmoi.os "darwin" }}
 # uv-managed Python with python3/python shims on PATH (~/.local/bin, PATH先頭).
 # Mason's PyPI installer requires python3 >= 3.10, but macOS system python is 3.9.6.

--- a/run_once_install-volta.sh.tmpl
+++ b/run_once_install-volta.sh.tmpl
@@ -25,9 +25,3 @@ volta install node
 volta install yarn
 volta install aicommits
 volta install ccusage
-
-# Install neovim package for Neovim Node.js support
-if ! npm list -g neovim >/dev/null 2>&1; then
-  log "Installing neovim npm package..."
-  npm install -g neovim
-fi


### PR DESCRIPTION
## 概要

MacBook での chezmoi セットアップを整備し、各種インストールスクリプトとツール設定を追加します。

## 変更内容

- **install**: macOS 向けに `gh`/`gitleaks`、`go`/`uv` (nvim Mason 用)、`wget` を追加
- **1Password SSH Agent**: GitHub 用にオプトインで有効化する通知スクリプトを追加
- **ssh**: `private_dot_ssh/modify_private_config.tmpl` を追加
- **nvim**: checkhealth (tree-sitter/providers) 修正、`options.lua` 調整
- **claude**: `settings.json` にスキーマ・attribution・ask-layer・品質デフォルトを追加
- **その他**: tmux/chezmoi 設定、`.chezmoiignore` で Makefile を無視、homebrew/python-tools/volta スクリプト調整

## テスト

- `make lint` 通過
- `chezmoi diff` / `chezmoi apply` で動作確認
