### PR TITLE
feat(install): add AI-era MCP servers and CLI tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/worktrees/
+.serena/

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -71,7 +71,8 @@
       "WebFetch(domain:*)",
       "mcp__plugin_context7_context7__resolve-library-id",
       "mcp__plugin_context7_context7__query-docs",
-      "mcp__serena"
+      "mcp__serena",
+      "mcp__playwright"
     ],
     "deny": [
       "Bash(sudo:*)",

--- a/private_dot_config/zsh/functions.zsh
+++ b/private_dot_config/zsh/functions.zsh
@@ -53,3 +53,16 @@ function gst() {
   stash=$(git stash list | fzf --preview 'echo {1} | sed "s/:$//" | xargs git stash show -p' | awk -F: '{print $1}')
   [ -n "$stash" ] && git stash show -p "$stash"
 }
+
+# One-shot question to Claude (non-interactive, uses subscription auth, no API key)
+# Usage: ask <question>   /   <command> | ask <question>
+function ask() {
+  [ $# -eq 0 ] && { echo "usage: ask <question>  (pipe stdin for context)" >&2; return 1; }
+  if [ ! -t 0 ]; then
+    local context
+    context=$(cat)
+    claude -p --model haiku -- "$@"$'\n\n---\n'"$context"
+  else
+    claude -p --model haiku -- "$@"
+  fi
+}

--- a/run_once_install-volta.sh.tmpl
+++ b/run_once_install-volta.sh.tmpl
@@ -25,3 +25,4 @@ volta install node
 volta install yarn
 volta install aicommits
 volta install ccusage
+volta install repomix

--- a/run_onchange_setup-mcp-servers.sh.tmpl
+++ b/run_onchange_setup-mcp-servers.sh.tmpl
@@ -34,7 +34,7 @@ register_mcp() {
 if command -v uvx >/dev/null 2>&1; then
   register_mcp serena -- \
     uvx --from git+https://github.com/oraios/serena serena start-mcp-server \
-    --context=claude-code --project-from-cwd
+    --context=claude-code --project-from-cwd --open-web-dashboard false
 else
   log "uvx not found. Skipping serena (install-python-tools provides uv)."
 fi

--- a/run_onchange_setup-mcp-servers.sh.tmpl
+++ b/run_onchange_setup-mcp-servers.sh.tmpl
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[mcp] $*"; }
+
+if [ -n "${CI:-}" ]; then
+  log "CI environment detected. Skipping MCP server setup."
+  exit 0
+fi
+
+# Ensure runtimes are on PATH for this script
+export PATH="$HOME/.local/bin:$PATH"
+export VOLTA_HOME="${VOLTA_HOME:-$HOME/.volta}"
+export PATH="$VOLTA_HOME/bin:$PATH"
+
+if ! command -v claude >/dev/null 2>&1; then
+  log "Claude CLI not found. Skipping MCP setup (install-claude handles installation)."
+  exit 0
+fi
+
+# Register a user-scoped MCP server only if it is not already present.
+# claude mcp add writes to ~/.claude.json (stateful), so this stays idempotent.
+register_mcp() {
+  local name="$1"; shift
+  if claude mcp get "$name" >/dev/null 2>&1; then
+    log "$name already registered"
+    return 0
+  fi
+  log "Registering MCP server: $name"
+  claude mcp add --scope user "$name" "$@"
+}
+
+# serena: LSP-based semantic code navigation (requires uvx, no API key)
+if command -v uvx >/dev/null 2>&1; then
+  register_mcp serena -- \
+    uvx --from git+https://github.com/oraios/serena serena start-mcp-server \
+    --context=claude-code --project-from-cwd
+else
+  log "uvx not found. Skipping serena (install-python-tools provides uv)."
+fi
+
+# playwright: browser automation / UI verification (requires npx, no API key)
+if command -v npx >/dev/null 2>&1; then
+  register_mcp playwright -- npx @playwright/mcp@latest
+else
+  log "npx not found. Skipping playwright (install-volta provides node)."
+fi


### PR DESCRIPTION
## 概要

AI時代の開発環境を強化する、**APIキー不要**（`claude` サブスク認証・ローカル実行で完結）のツール群を追加します。既存ネイティブ機能（`gh` CLI / `WebFetch` / context7）と重複するものは意図的に除外しています。

> [!NOTE]
> ベースが `main` のため、未マージの `feature/macbook_setup` の9コミットも差分に含まれます。本PR固有の変更は下記の **3コミット**です。

## 本PRで追加する変更

### 1. serena / playwright MCP サーバー (`feat(install): add serena and playwright MCP setup`)
- 新規 `run_onchange_setup-mcp-servers.sh.tmpl` — `claude mcp add --scope user` で冪等登録
  - **serena** (uvx): LSPベースのセマンティックコードナビ。**settings.json で許可だけ先行付与されていたのに未配線だった**問題を解消
  - **playwright** (npx): ブラウザ操作 / UI検証
- ランタイムごとに独立ガード（uvx/npx 欠如時はそのサーバーのみスキップ）
- `claude mcp get` で既存判定 → 未登録時のみ追加（`~/.claude.json` はステートフルなため）
- `dot_claude/settings.json` の `permissions.allow` に `mcp__playwright` を追加
- serena 自動生成の `.serena/` を `.gitignore`

### 2. repomix (`feat(install): add repomix to volta global packages`)
- リポジトリを1ファイルに束ねて LLM / Web chat に投入。`aicommits`/`ccusage` と同パターン

### 3. `ask` シェル関数 (`feat(zsh): add ask function for one-shot Claude queries`)
- `claude -p` ラッパーでターミナルからワンショット質問。既存サブスク認証を流用（キー不要）
- stdin パイプをコンテキストとして併合

## 検証
- `make lint` (JSON) パス、`bash -n` / `zsh -n` 構文OK、`chezmoi execute-template` 展開OK
- スクリプト実行 → `claude mcp get serena/playwright` ともに **✔ Connected** 確認
- 再実行で冪等性確認（重複登録なし）
- `ask "..."` / `echo ... | ask "..."` の応答・stdin併合を実機確認
- code-reviewer によるセルフレビュー実施（`ask` の `"$@"`+`--` 堅牢化を反映）

## 除外したもの（理由）
- github MCP / fetch MCP: 既存の `gh` CLI 権限・`WebFetch`+context7 で代替済み
- sequential-thinking: `alwaysThinkingEnabled` と重複