### PR TITLE
feat(install): install memo on macOS via go install

### DIFF
--- a/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
@@ -36,4 +36,10 @@ brew install \
   tmux \
   tree-sitter-cli \
   wget
+
+# Go tools not available via Homebrew
+if ! command -v memo >/dev/null 2>&1; then
+  log "Installing memo..."
+  go install github.com/mattn/memo@latest
+fi
 {{ end }}


### PR DESCRIPTION
## 背景

mac 環境で \`memo\`(mattn/memo) が入っていなかった。

\`memo\` は Homebrew formula が存在せず \`go install\` が必要だが、その処理は Linux 専用スクリプト (\`run_once_install-linux-packages.sh.tmpl\`、\`{{ if eq .chezmoi.os \"linux\" }}\` ガード内) にしか無く、mac 側 (\`run_once_install-homebrew.sh.tmpl\`) には存在しなかった。

mac の Homebrew では \`go\`/\`ghq\`/\`glow\` は formula で入るが、\`memo\` だけ抜け落ちていた。

## 変更内容

\`run_once_install-homebrew.sh.tmpl\` の \`brew install\`(\`go\` を含む)直後に、Linux 側と同じパターンで \`go install\` ブロックを追加:

\`\`\`bash
# Go tools not available via Homebrew
if ! command -v memo >/dev/null 2>&1; then
  log "Installing memo..."
  go install github.com/mattn/memo@latest
fi
\`\`\`

- \`brew install ... go\` で go が入った直後に実行されるため go は利用可能
- \`command -v\` ガードで冪等性を確保(再 apply 時に再インストールしない)
- 出力は prelude の \`log()\` を使用(Linux 側と統一)

## 補足

Docker も当初要望にあったが、企業環境で Docker Desktop が使えるとは限らないため **dotfiles では管理しない**(対象外)とした。

## テスト

- \`chezmoi execute-template\` で darwin 向けに memo ブロックが正しく展開されることを確認
- \`make lint\` パス
- pre-commit(shellcheck 等)パス