### PR TITLE
fix(claude): deploy authored skills and sync settings

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -7,7 +7,9 @@ docs/
 .stylua.toml
 
 # Claude Code auto-generated / transient files
-.claude/skills/
+# NOTE: .claude/skills/ is NOT ignored — authored skills (auto-commit, commit,
+# consult, …) live there and must be deployed. chezmoi only manages files
+# present in the source, so runtime-generated skills are left untouched.
 .claude/.update.lock
 .claude/shell-snapshots/
 .claude/plugins/

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -7,7 +7,6 @@ Project-specific instructions are in each project's `CLAUDE.md`.
 - **Language**: Think in English. Respond in Japanese.
 - **Library docs**: Use Context7 MCP before implementing anything library-specific.
 - **Worktree isolation**: Always use git worktree for feature work and bug fixes. Never work directly on main. Use `isolation: "worktree"` with the Agent tool.
-- **Superpowers skills**: Actively use superpowers skills whenever applicable.
 - **Agentic coding**: Prefer autonomous, agent-driven approaches — subagents, parallel execution, proactive problem-solving.
 - **PRs**: Commit and push to feature branches without asking. Always ask before creating a PR.
 
@@ -18,4 +17,4 @@ Project-specific instructions are in each project's `CLAUDE.md`.
 **Types**: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`
 
 - Subject: ≤50 chars, imperative mood, no trailing period
-- Body: *what* and *why*, not *how*; wrap at 72 chars
+- Body: _what_ and _why_, not _how_; wrap at 72 chars

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -11,6 +11,7 @@
       "Read(~/.claude/**)",
       "Edit(**)",
       "Write(**.md)",
+      "Write(/tmp/**)",
       "Write(.tmp/**)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
@@ -87,10 +88,7 @@
       "Read(id_ed25519)",
       "Write(.env*)"
     ],
-    "ask": [
-      "Bash(gh pr create:*)",
-      "Bash(gh pr merge:*)"
-    ],
+    "ask": ["Bash(gh pr create:*)", "Bash(gh pr merge:*)"],
     "defaultMode": "plan"
   },
   "model": "opus",

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -1,6 +1,8 @@
 [user]
   name = {{ .name }}
   email = {{ .email }}
+[ghq]
+  user = {{ .name }}
 [color]
   ui = true
 [color "diff"]


### PR DESCRIPTION
## Summary
- authored skills が `~/.claude/skills/` に配布されない不具合を修正
- Claude 設定と git template を同期

## Changes
- **fix(claude)**: `.chezmoiignore` から `.claude/skills/` の除外を解除。commands→skills 移行で `.claude/skills/` が ignore されたまま残り、authored skills（auto-commit, commit, consult, deep, ultra-think）が配布されず `git aic` が `Unknown command: /auto-commit` で失敗していた。chezmoi は source にあるファイルのみ管理するため、ランタイム生成スキルは影響を受けない。
- **chore(claude)**:
  - `dot_claude/CLAUDE.md`: 冗長な superpowers 記述を削除、markdown整形（`*text*` → `_text_`）
  - `dot_claude/settings.json`: `Write(/tmp/**)` 権限追加、`ask` セクション整形
  - `dot_gitconfig.tmpl`: `[ghq] user` 設定を追加

## Test plan
- `make lint` がパス
- `chezmoi diff` → `chezmoi apply` で `~/.claude/skills/` に5スキルが配布されることを確認