### PR TITLE
perf(claude): speed up auto-commit by reading key files only

### DIFF
--- a/dot_claude/skills/auto-commit/SKILL.md
+++ b/dot_claude/skills/auto-commit/SKILL.md
@@ -1,35 +1,48 @@
 ---
-description: Stage-aware auto commit — analyze staged diff file by file, then commit
+description: Stage-aware auto commit — read key files in full, the rest by name, then commit
 argument-hint: [optional context]
 ---
 
-# Auto Commit (staged, file-by-file)
+# Auto Commit (staged, fast)
 
-Analyze the **staged** changes incrementally (file by file), generate a
-Conventional Commits message, and create the commit immediately. No editor
-prompt, no confirmation — this runs fully automatically.
+Analyze the **staged** changes — reading the key files in full and the rest by
+name — generate a Conventional Commits message, and create the commit
+immediately. No editor prompt, no confirmation — this runs fully automatically.
 
 This is the engine behind the `git ai` / `git aic` shell wrappers, which run
 this skill headless via `claude -p` with `--permission-mode acceptEdits` and a
 git-only `--allowedTools` allowlist — least privilege, not a full bypass.
 
+Keep tool calls to a few: one overview, a handful of targeted diffs, the style
+check, and the commit. Do **not** crawl the diff file by file — that is slow on
+large changesets and rarely changes the message.
+
 ## Instructions
 
-1. **List staged files**
+1. **Survey staged files in one shot**
    ```bash
    git diff --cached --stat
    ```
    - If there are no staged changes, print `No staged changes` and stop. Do not
      stage anything yourself — staging is the wrapper's job.
+   - This single overview lists every file with its insertion/deletion counts —
+     enough to judge which files actually need a close read.
 
-2. **Read the diff incrementally — one file at a time**
-   For each staged file, inspect its diff on its own rather than reading the
-   whole diff at once. This keeps large changesets accurate.
+2. **Read only the files that matter**
+   From the `--stat` overview, pick the files carrying the substance of the
+   change and read just those in full:
    ```bash
    git diff --cached -- <file>
    ```
-   - For a very large file, walk it hunk by hunk.
-   - For each file, note a one-line summary of *what changed and why*.
+   - Read in full the **largest few files** — rough guide: the top 3–5 by
+     changed lines, or any file over ~30 changed lines.
+   - For the rest, rely on the filename and its `--stat` insertion/deletion
+     counts — do not diff them.
+   - Skip the contents of lock/generated files (`*-lock.json`, `*.lock`,
+     minified bundles) entirely — the filename is enough.
+   - If the whole changeset is small (few files, low line count), just read it
+     all; the goal is to avoid a long file-by-file crawl on big changesets, not
+     to withhold context when it is cheap.
 
 3. **Check commit style**
    ```bash


### PR DESCRIPTION
## Summary
`git aic` / `git ai` が遅い原因を解消する。`/auto-commit` skill が**全ファイルを1つずつ full diff で精読**していたため、変更ファイルが多いとエージェントのツール呼び出し（ターン）が増えて遅かった。重要ファイルだけ精読する方式に変更し、git 操作を数回（a few）に抑える。

## Changes
`dot_claude/skills/auto-commit/SKILL.md` の手順1〜2を差し替え（bash ラッパーは変更なし、薄いまま）:
- **手順1**: `git diff --cached --stat` で全体を**1回**で概観
- **手順2**: 変更行数の大きい**上位3〜5ファイル（または30行超）だけ** `git diff --cached -- <file>` で精読。残りはファイル名＋増減で判断。ロック/生成物は中身を読まない。変更が小さければ従来どおり全精読
- ツール呼び出しが「stat 1 + 重要 diff 数件 + log 1 + commit 1」に収束

## ⚠️ 依存
実機 `~/.claude` への配布には **#89（`.claude/skills/` の unignore）が前提**。main では現状 `.claude/skills/` が ignore され SKILL.md は `not managed`。#89 マージ後にこの変更が有効化される。マージ順は問わない。

## Test plan
- `make lint` パス
- `pre-commit run --files dot_claude/skills/auto-commit/SKILL.md` パス
- #89 マージ後、`chezmoi apply` → `git aic` で大きめの変更をコミットし、ツール呼び出しが減って高速化することを確認