### PR TITLE
feat(claude): add local lint hook for edited files

### DIFF
--- a/.claude/hooks/precommit-lint.sh
+++ b/.claude/hooks/precommit-lint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# PostToolUse(Write|Edit) hook: lint/format the file Claude just touched.
+#
+# Reuses this repo's .pre-commit-config.yaml as the single source of truth so
+# the local check matches the pre-commit / CI gate exactly. Runs every hook
+# except the slow secret scanner. On failure the output is fed back to Claude
+# (exit 2) so issues are fixed immediately, before commit.
+set -euo pipefail
+
+input=$(cat)
+file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_response.filePath // empty')
+[ -n "$file" ] || exit 0
+[ -f "$file" ] || exit 0
+
+# Only act on file types our pre-commit config knows about (sh, nvim lua,
+# chezmoi templates, toml, yaml, json). Anything else is a fast no-op.
+case "$file" in
+*.lua | *.sh | *.sh.tmpl | *.tmpl | *.toml | *.yaml | *.yml | *.json) ;;
+*) exit 0 ;;
+esac
+
+# Resolve the git repo that owns the file; bail if it isn't a repo or has no config.
+repo=$(git -C "$(dirname "$file")" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -f "$repo/.pre-commit-config.yaml" ] || exit 0
+command -v pre-commit >/dev/null 2>&1 || exit 0
+
+rel=${file#"$repo"/}
+if ! out=$(cd "$repo" && SKIP=gitleaks pre-commit run --files "$rel" 2>&1); then
+	printf 'pre-commit found issues in %s:\n\n%s\n' "$rel" "$out" >&2
+	exit 2
+fi
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/precommit-lint.sh",
+            "statusMessage": "Running pre-commit linters..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,11 @@ All changes go through PRs. Never commit directly to main.
 5. `gh pr checks <PR#>` — all CI must pass. Fix failures, never use `--admin` to bypass
 6. Merge after review + CI pass
 
+**Standing rule:** after opening a PR, always verify CI is green
+(`gh pr checks <PR#> --watch`) and then merge it — no need to ask again once
+the checks pass. Never merge with failing or pending checks; fix failures
+instead of bypassing them.
+
 ### Parallel Work Rules
 - Use `isolation: "worktree"` for concurrent agents
 - Never parallelize issues that touch the same files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,20 @@ Configured in `.pre-commit-config.yaml`: check-toml, check-yaml, end-of-file-fix
 
 Never bypass with `--no-verify` — investigate and fix failures.
 
+### Local Lint Hook (Claude Code)
+
+A Claude Code `PostToolUse` hook lints/formats each file right after Claude
+edits it — so shellcheck (`.sh`), stylua (nvim `.lua`), template, TOML, YAML
+checks surface immediately instead of waiting for `git commit`.
+
+- Config: `.claude/settings.json` → `.claude/hooks/precommit-lint.sh`
+- Mechanism: runs `pre-commit run --files <edited-file>`, reusing
+  `.pre-commit-config.yaml` as the single source of truth (same gate as CI)
+- `gitleaks` is skipped (`SKIP=gitleaks`) for speed; secrets are still caught
+  at real commit time and in CI
+- Failures are fed back to Claude (exit 2) for immediate fixing
+- Requires `pre-commit` installed locally; non-matching files are a no-op
+
 ## Workflow
 
 1. Edit source files directly in this repo


### PR DESCRIPTION
## 概要

Claudeがファイルを編集した直後に lint/formatter をローカルで走らせる `PostToolUse(Write|Edit)` フックを追加します。`shellcheck`(.sh)、`stylua`(nvim .lua)、template / TOML / YAML チェックが `git commit` を待たず即座に表面化します。

## 仕組み

- **`.claude/hooks/precommit-lint.sh`** — フック本体
  - 編集ファイルに `pre-commit run --files <file>` を実行し、`.pre-commit-config.yaml` を**単一の真実の源**として再利用(ローカルチェック = CIゲート)
  - 対象拡張子: `.lua` / `.sh` / `.tmpl` / `.toml` / `.yaml` / `.json`、それ以外は即 no-op
  - `gitleaks` は速度のため `SKIP=gitleaks` で除外(コミット時・CIでは有効のまま)
  - lint失敗時は出力を **exit 2** でClaudeに返し、その場で修正させる
- **`.claude/settings.json`**(コミット対象・プロジェクト全体)にフックを登録
- **CLAUDE.md** の Pre-commit Hooks 節に「Local Lint Hook」サブセクションを追記

## 検証

| ケース | 結果 |
|---|---|
| クリーンなlua | exit 0 |
| eof欠落のlua | 自動修正 + exit 2 |
| sh構文エラー | shellcheck失敗を詳細付きで exit 2 |
| 未追跡(新規作成)ファイル | lint対象になる |
| 対象外(.md)/ 空path | no-op exit 0 |
| フックスクリプト自身のshellcheck | Passed |
| `make lint` / 全変更へのpre-commit | Passed |

## 設計上の判断

- standalone linter(shellcheck/stylua等)はPATHに無く `pre-commit` 環境内にのみ存在 → pre-commit再利用が唯一現実的かつ二重管理を回避
- リポジトリ固有のフックのため、汎用配布の `dot_claude/` ではなくこのリポジトリの `.claude/` に配置

## 注意

設定watcherの仕様上、`.claude/settings.json` を新規作成したセッションでは有効化されない場合があります。次回セッション以降、または `/hooks` を一度開くと有効になります。