### PR TITLE
feat(claude): auto-log sessions to Obsidian worklog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,14 @@ Never bypass with `--no-verify` — investigate and fix failures.
 ## Workflow
 
 1. Edit source files directly in this repo
-2. `make lint` → `chezmoi diff` → `chezmoi apply`
+2. `make lint` → `chezmoi diff` (preview only — do **not** `chezmoi apply` yet)
 3. Commit and create PR
+4. **After the PR is merged**, run `chezmoi apply` to sync changes to this machine
+
+**Standing rule:** Never `chezmoi apply` before a PR is merged. Verify changes
+during review with `chezmoi diff` (use `--source <worktree>` to preview from a
+feature worktree). Apply only after merge, so the live machine always reflects
+merged, reviewed state.
 
 ## PR-Driven Development (Required)
 
@@ -76,4 +82,5 @@ instead of bypassing them.
 
 - `.tmpl` files contain Go template syntax — preserve `{{ }}` blocks
 - `run_once_` scripts run only once; to re-run, delete state in `.chezmoistate.boltdb`
-- After editing `dot_claude/`, run `chezmoi apply` to sync to `~/.claude/`
+- Editing `dot_claude/` only changes the source; it reaches `~/.claude/` via
+  `chezmoi apply`, which runs **after the PR is merged** (see Workflow above)

--- a/dot_claude/hooks/executable_worklog.sh
+++ b/dot_claude/hooks/executable_worklog.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SessionEnd hook: append a per-session work-log entry to a daily Obsidian note.
+#
+# Output goes to $CLAUDE_WORKLOG_DIR/YYYY-MM-DD.md, one section per session.
+# The hook is intentionally machine-agnostic: if CLAUDE_WORKLOG_DIR is unset
+# (e.g. a host without the vault) it no-ops, and it NEVER fails the session
+# (always exits 0) so a logging glitch can't disrupt Claude Code.
+set -uo pipefail
+
+# Read the SessionEnd payload (session_id, transcript_path, cwd, reason).
+input="$(cat)"
+
+# Keep dot_claude portable: do nothing unless an output dir is configured.
+[ -n "${CLAUDE_WORKLOG_DIR:-}" ] || exit 0
+
+# Parse the payload and best-effort summary in a single Python pass.
+# Output: line 1 = "cwd<TAB>reason<TAB>session_id<TAB>started",
+#         then a "---8<---" delimiter, then the multi-line summary.
+parsed="$(CLAUDE_HOOK_PAYLOAD="$input" python3 - <<'PY' 2>/dev/null || true
+import os, json
+
+payload = {}
+try:
+    payload = json.loads(os.environ.get("CLAUDE_HOOK_PAYLOAD", "{}"))
+except Exception:
+    payload = {}
+
+cwd = payload.get("cwd", "") or ""
+reason = payload.get("reason", "") or ""
+session_id = payload.get("session_id", "") or ""
+transcript = payload.get("transcript_path", "") or ""
+
+def text_of(content):
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                out.append(b.get("text", ""))
+        return "\n".join(out)
+    return ""
+
+started = ""
+first_user = ""
+last_asst = ""
+try:
+    with open(transcript, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                e = json.loads(line)
+            except Exception:
+                continue
+            if not started and e.get("timestamp"):
+                started = e["timestamp"]
+            msg = e.get("message") or {}
+            role = msg.get("role") or e.get("type")
+            if role == "user" and not first_user:
+                t = text_of(msg.get("content")).strip()
+                # skip tool results / system-injected meta turns
+                if t and not t.startswith("<"):
+                    first_user = t
+            if role == "assistant":
+                t = text_of(msg.get("content")).strip()
+                if t:
+                    last_asst = t
+except Exception:
+    pass
+
+def clip(s, n):
+    s = " ".join(s.split())
+    return s[:n] + ("…" if len(s) > n else "")
+
+summary = ""
+if first_user:
+    summary += "**依頼**: " + clip(first_user, 400)
+if last_asst:
+    summary += ("\n\n" if summary else "") + "**結果**: " + clip(last_asst, 600)
+
+print("\t".join([cwd, reason, session_id, started]))
+print("---8<---")
+print(summary)
+PY
+)"
+
+# Split Python output into the metadata line and the summary block.
+meta="$(printf '%s\n' "$parsed" | head -n1)"
+summary="$(printf '%s\n' "$parsed" | awk 'f{print} /^---8<---$/{f=1}')"
+
+IFS=$'\t' read -r cwd reason session_id started <<<"$meta"
+[ -n "${cwd:-}" ] || cwd="$PWD"
+
+# Git context (best effort; skipped cleanly for non-git directories).
+repo=""
+branch=""
+changed=""
+commits=""
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  top="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
+  [ -n "$top" ] && repo="$(basename "$top")"
+  branch="$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+  changed="$(git -C "$cwd" diff --shortstat 2>/dev/null | sed 's/^ *//')"
+  if [ -n "${started:-}" ]; then
+    commits="$(git -C "$cwd" log --since="$started" --pretty=format:'%h %s' 2>/dev/null | head -n 20)"
+  fi
+fi
+
+# Compose and append the entry. Never let a write error fail the session.
+mkdir -p "$CLAUDE_WORKLOG_DIR" 2>/dev/null || exit 0
+out="$CLAUDE_WORKLOG_DIR/$(date +%Y-%m-%d).md"
+{
+  printf '\n## %s %s (%s)\n\n' "$(date +%H:%M)" "${repo:-$(basename "$cwd")}" "${branch:-no-git}"
+  [ -n "$summary" ] && printf '%s\n\n' "$summary"
+  [ -n "$changed" ] && printf -- '- Changed: %s\n' "$changed"
+  if [ -n "$commits" ]; then
+    printf -- '- Commits:\n'
+    printf '%s\n' "$commits" | while IFS= read -r c; do printf '    - %s\n' "$c"; done
+  fi
+  # shellcheck disable=SC2016  # backticks are literal markdown, not a subshell
+  printf -- '- Session: %s · `%s`\n' "${reason:-unknown}" "${session_id:0:8}"
+} >>"$out" 2>/dev/null || true
+
+exit 0

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -71,8 +71,6 @@
       "Bash(uname:*)",
       "WebFetch(domain:*)",
       "WebSearch",
-      "mcp__obsidian__vault_list",
-      "mcp__obsidian__vault_read",
       "mcp__plugin_context7_context7__query-docs",
       "mcp__plugin_context7_context7__resolve-library-id",
       "mcp__serena",
@@ -117,6 +115,17 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/stop-review.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/worklog.sh"
           }
         ]
       }

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -32,3 +32,8 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Cargo (Rust)
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
+
+# Claude Code work-log output dir (consumed by ~/.claude/hooks/worklog.sh).
+# Only set when the Obsidian vault exists; the hook no-ops if this is unset,
+# keeping ~/.claude portable across machines without the vault.
+[ -d "$HOME/Documents/ob_edgissa" ] && export CLAUDE_WORKLOG_DIR="$HOME/Documents/ob_edgissa/claude/worklog"


### PR DESCRIPTION
## 概要

セッション終了ごとに「何をやったか」を Obsidian vault の日次 worklog に自動追記する `SessionEnd` フックを追加。試行錯誤の作業履歴がどこにも残らない問題(柱1: 知識・作業履歴の保持)を埋める。

壁打ち設計の結論に基づく:
- 知識は2層に役割分担。**Layer 1(curated知見/rules)= file-based memory は現状維持(YAGNI)**、**Layer 2(作業履歴)= Obsidian vault** ← 本PRのスコープ。
- vault はローカルにあるため MCP は不要。ファイル直アクセス + フックで追記する方が再現性◎・ヘッドレス◎・依存ゼロ。スマホ閲覧は Obsidian 同期が担う。

## 変更

| ファイル | 内容 |
|---|---|
| `dot_claude/hooks/executable_worklog.sh`(新規) | SessionEnd フック。transcript から要約(依頼/結果)+ git メタ(branch/diff stat/セッション中のコミット)を `$CLAUDE_WORKLOG_DIR/YYYY-MM-DD.md` に追記 |
| `dot_claude/settings.json` | `SessionEnd` フック登録 + 死んだ `mcp__obsidian__vault_*` 権限を削除(未登録かつ読み取り専用) |
| `dot_zshenv.tmpl` | vault 存在時のみ `CLAUDE_WORKLOG_DIR` を export(ガード付き) |
| `CLAUDE.md` | `chezmoi apply` は **PRマージ後** に実施するルールを明記 |

## 設計上のポイント

- フックは**完全にマシン非依存**。`CLAUDE_WORKLOG_DIR` 未設定なら静かに no-op、何があっても `exit 0`(ログ失敗がセッションを壊さない)。マシン固有の vault パスは chezmoi 側(zshenv)に分離し `dot_claude/` はポータブル維持。
- 要約は transcript の jsonl パースのみ(追加 LLM 呼び出しなし=軽量・確実)。

## 検証

- ✅ 正常系: 要約・git 情報・セッション行が正しく生成
- ✅ 異常系: `CLAUDE_WORKLOG_DIR` 未設定 / transcript 不正 / 非git / 空・不正JSON → すべて `exit 0` で無害
- ✅ `make lint` / pre-commit(shellcheck・gitleaks・chezmoi template) green
- ✅ `chezmoi diff` でフックが `100755`(実行権限付き)展開、全ファイル意図どおり

## 適用

レビュー中は `chezmoi diff` でプレビューのみ。**マージ後に `chezmoi apply`** で本マシンへ反映する。