### PR TITLE
chore(claude): adopt tui fullscreen setting into source

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -159,5 +159,6 @@
   },
   "language": "japanese",
   "preferredNotifChannel": "auto",
-  "editorMode": "vim"
+  "editorMode": "vim",
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## What

ライブ `~/.claude/settings.json` を直接編集した際に増えた `tui: "fullscreen"` を、chezmoi ソース `dot_claude/settings.json` に取り込む。

## Why

`/chezmoi-claude-sync` でドリフトを検出（`chezmoi status` → `MM .claude/settings.json`）。ライブとソースを正規化比較した結果、意味的な差分は `tui: "fullscreen"` の1点のみ。これはマシン非依存のUI設定でポータブル方針に合致するため、ソースへ採用する。

その他の生 diff（`env`/`alwaysThinkingEnabled`/`effortLevel` のキー順序移動、`ask` 配列の整形差）は JSON 上意味のないノイズのため取り込まず、ライブのドリフトとして残す（revert は merge 後の `chezmoi apply` 対応）。

## Verification

- `git diff` → `tui` 行追加のみ（最小差分）
- `make lint-json` → All JSON files valid
- `chezmoi diff`（worktree ソース）→ `tui` は一致、残差分は順序/整形ノイズのみ
- `chezmoi apply` は未実行（standing rule 遵守、merge 後に反映）