### PR TITLE
feat(claude): add research-coordinator agent and strengthen delegation

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -2,8 +2,11 @@
 # NOTE: .chezmoiignore patterns match the TARGET path (not gitignore-style), so
 # a bare `CLAUDE.md` only ignores the repo root. Use `**/CLAUDE.md` to keep
 # nested authoring docs (e.g. private_dot_config/nvim/CLAUDE.md) repo-only.
+# Exception: `.claude/CLAUDE.md` is the deployable global Claude instructions
+# (dot_claude/CLAUDE.md), so re-include it with a negation below.
 CLAUDE.md
 **/CLAUDE.md
+!.claude/CLAUDE.md
 README.md
 Makefile
 scripts/

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,7 +1,10 @@
 # Global Guidelines
 
+Project-specific instructions are in each project's `CLAUDE.md`.
+
 ## Rules
 
+- **Language**: Think in English. Respond in Japanese.
 - **Library docs**: Use Context7 MCP before implementing anything library-specific.
 - **Worktree isolation**: Always use git worktree for feature work and bug fixes. Never work directly on main. Use `isolation: "worktree"` with the Agent tool.
 - **Agentic coding**: Prefer autonomous, agent-driven approaches — subagents, parallel execution, proactive problem-solving.
@@ -13,6 +16,12 @@
 - Offload research, exploration, and parallel analysis to subagents
 - For complex problems, throw more compute at it via subagents
 - One tack per subagent for focused execution
+- Default to delegating: don't hold exploration, research, or cross-cutting
+  analysis in the main context — hand it to a subagent
+- Route broad, multi-area investigations to the `research-coordinator` agent
+- Tell every child to return conclusions only (no raw logs) to protect main context
+- Run independent tasks in parallel; keep nested subagents shallow and wide
+  (don't waste the depth-5 nesting limit on tall chains)
 
 ## Verification Before Done
 

--- a/dot_claude/agents/research-coordinator.md
+++ b/dot_claude/agents/research-coordinator.md
@@ -1,0 +1,38 @@
+---
+name: research-coordinator
+description: Research coordinator that decomposes broad, cross-cutting investigations and fans them out to specialized subagents in parallel, returning only synthesized conclusions. Use PROACTIVELY when a question spans multiple areas of the codebase, compares several libraries or approaches, or needs both code exploration and web research at once.
+tools: Agent(Explore, search-specialist), Read, Grep
+model: sonnet
+---
+
+You are a research coordinator. Your job is to break a broad question into independent
+sub-questions, delegate them to specialized subagents in parallel, and return a single
+synthesized answer to the main conversation. You do the orchestration and synthesis — you
+do not do the deep searching yourself.
+
+## When invoked
+
+1. Restate the objective and split it into independent sub-questions (one concern each).
+2. Dispatch subagents **in parallel** (one message, multiple tool calls):
+   - `Explore` for anything inside the codebase (implementations, patterns, call paths).
+   - `search-specialist` for anything on the web (library specs, latest docs, comparisons).
+3. Give every child this instruction explicitly:
+   > Your final output IS your return value. Return only conclusions and evidence
+   > (file paths / URLs). Do NOT return raw logs, file dumps, or your process.
+4. Collect the children's results, **synthesize them yourself**, and return to the main
+   conversation **only** the conclusions plus their evidence. The children's raw output
+   dies in your context — it must not leak back to the main context.
+
+## Principles
+
+- Shallow and wide. Aim for depth 2–3; never burn the depth-5 nesting limit on tall chains.
+- One task per child. Focused prompts beat broad ones.
+- If you cap coverage (top-N sources, a subset of files), say so explicitly in the result.
+- Prefer fewer, well-scoped children over many overlapping ones — each child has a real
+  startup and return cost.
+
+## Output
+
+- Direct answer to the objective, organized by sub-question.
+- Evidence for each claim: codebase `file_path:line` references and source URLs.
+- Open questions or gaps, and any coverage you deliberately skipped.


### PR DESCRIPTION
## Why

メインの agent ばかり動き、サブエージェントが活用されていなかった。原因はカスタムエージェント不在ではなく、(1) 委譲がメイン判断頼み、(2) 自動委譲を誘発する専門エージェント不在、(3) グローバルガイドラインの委譲指示がソフトなため。最新 Claude Code の nested subagents（子が孫を呼ぶ、深さ最大5）を全プロジェクトで活かすため、chezmoi の `dot_claude/` にグローバル設定として落とす。

## What

- **(a)** `dot_claude/agents/research-coordinator.md` 新設。横断調査を `Explore`（コード）/ `search-specialist`（Web）へ**並列 fan-out → 結論のみ集約**するコーディネーター。子を呼べるのはこのエージェントだけ（`tools: Agent(Explore, search-specialist), Read, Grep`）、末端ワーカーは non-nesting を維持。
- **(b)** グローバル `dot_claude/CLAUDE.md` の Subagent Strategy を強化（委譲をデフォルト化／横断調査は research-coordinator へ／子には結論のみ返却を要求／nested は浅く広く）。

## Incidental fix

`.chezmoiignore` の `**/CLAUDE.md` が配布対象の `~/.claude/CLAUDE.md` まで巻き添えで無効化しており、`dot_claude/CLAUDE.md` の編集が live に一度も届いていなかった（commit a336d3a の Subagent Strategy も未到達）。`!.claude/CLAUDE.md` で除外解除し、live 固有の `Language` ルール／intro 行を source へ取り込んで drift を解消。`chezmoi diff` 上、live への変更は**追加のみ**で削除なしを確認済み。

## Verification

- `make lint` ✅ / pre-commit（end-of-file, trailing-whitespace, gitleaks 等）✅
- `chezmoi diff --source <worktree>`：エージェント新規追加 + CLAUDE.md は追加のみを確認
- マージ後 `chezmoi apply` → 別プロジェクトで横断質問を投げ、メインが research-coordinator へ自動委譲し結論のみ返ることを観察予定