### PR TITLE
feat(zsh): add random startup tip with maintenance skill

### DIFF
--- a/.claude/skills/zsh-tips/SKILL.md
+++ b/.claude/skills/zsh-tips/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: zsh-tips
+description: Add or curate the zsh startup tip rotation (private_dot_config/zsh/tips.txt) in this dotfiles repo. Use this whenever the user wants more shell tips or to grow the startup tip pool — phrases like 「tip増やして」「zshのtip追加して」「便利コマンド集に足して」「起動メッセージのバリエーション増やして」, or just "add some zsh tips". It reads tips.txt plus the repo's real aliases/functions/tools and appends new, non-duplicate, correctly-formatted tips. Always prefer this over hand-writing tips, so the format and dedup stay consistent.
+argument-hint: [number of tips and/or a theme, e.g. "5 git tips"]
+---
+
+# zsh 起動Tip メンテナンス
+
+この dotfiles リポジトリには zsh 起動時にランダムな便利Tipを1件表示する仕組みが
+ある（`private_dot_config/zsh/tips.zsh` が `tips.txt` を読んで表示）。この skill は
+その **Tipプール (`tips.txt`) を育てる**ためのもの。表示ロジックには触れない。
+
+肝は「実在するものだけを、重複なく、正しい形式で足す」こと。汎用的なシェル豆知識を
+並べるのではなく、**このユーザーが実際に使える** alias / 関数 / 導入済みツールに
+根ざした Tip を作るのが価値になる（だから起動時に出して役立つ）。
+
+## データ形式
+
+`tips.txt` は1行1Tip、パイプ区切りの3フィールド:
+
+```
+category|trigger|description
+```
+
+- `category`: `zsh` / `git` / `tool` のいずれか（表示色がカテゴリで変わる）
+- `trigger`: コマンド名や alias。実在するものだけ（例 `gb`, `gwta <path>`, `mdp`）
+- `description`: 日本語1行の簡潔な説明
+- 区切りは**最初の2つの `|` だけ**。`description` 内に `|` を含めてよい
+  （例: `zsh|ask|claude -p をワンショット。\`cmd | ask 質問\` で文脈も渡せる`）
+- `#` 始まりの行と空行は無視される
+
+## ワークフロー
+
+### 1. 既存を読んで把握する
+
+`private_dot_config/zsh/tips.txt` を読み、フォーマットと**既存の trigger 一覧**を
+頭に入れる。新しい Tip は既存 trigger と重複させない。
+
+### 2. 真実の源から素材を集める
+
+Tip は次の実ファイルに**実在する**ものだけから作る（推測で書かない）:
+
+- `private_dot_config/zsh/functions.zsh` — 自作関数（`gb` `glog` `gpr` `gst`
+  `mdp` `sshf` `ask` など）
+- `private_dot_config/zsh/aliases.zsh.tmpl` — alias（`g` `vim` `cw` `vlast`
+  `gwt`/`gwta`/`gwtr` `ma` など）
+- `private_dot_config/zsh/plugins.zsh` — 導入ツール（fzf, atuin, starship,
+  direnv など）
+
+git/gh ワークフローやツール一般の Tip を足す場合も、このリポジトリ/環境で実際に
+使える範囲に留める。ユーザーがテーマ（例「git のTipだけN個」）を指定したら従う。
+
+### 3. 生成して追記する
+
+`category|trigger|description` 形式で指定件数（デフォルト5件程度）を生成し、
+`tips.txt` の**末尾に追記**する。
+
+- 日本語・1行・簡潔
+- 既存 trigger と重複させない
+- 末尾に空白を付けない（pre-commit の trailing-whitespace で弾かれる）
+- 関連カテゴリの既存ブロックの近くに置くと読みやすいが、末尾追記でも可
+
+### 4. 検証する
+
+追記後、最低限これを確認する:
+
+```bash
+# フィールド不足の行（description 内の | は許容なので NF<3 だけが異常）
+grep -vE '^[[:space:]]*(#|$)' tips.txt | awk -F'|' 'NF<3{print "BAD:",$0}'
+# trigger 重複
+grep -vE '^[[:space:]]*(#|$)' tips.txt | awk -F'|' '{print $2}' | sort | uniq -d
+```
+
+両方とも出力が空なら健全。可能なら実表示も確認:
+
+```bash
+zsh -c 'source private_dot_config/zsh/tips.zsh; tip private_dot_config/zsh/tips.txt'
+```
+
+### 5. chezmoi フローを守る
+
+ここで触るのは chezmoi **ソース**だけ。`chezmoi apply` はしない
+（このリポジトリの標準: 編集 → PR → **マージ後**に apply）。変更は PR で出す。
+
+## 例
+
+**Input:** 「git worktree 系のTipを2つ増やして」
+
+**Output（tips.txt 末尾に追記）:**
+```
+git|git worktree prune|削除済み worktree の登録を掃除（git worktree prune）
+git|gwta + cd|`gwta ../wt-foo branch` で作業場所を分けてから移動すると安全
+```
+
+**Input:** 「tip 5個足して」（テーマ指定なし）
+
+→ functions.zsh / aliases.zsh.tmpl / plugins.zsh を読み、まだ Tip 化されて
+いない実在の関数・alias・ツールを優先して5件作り、重複チェックして追記する。

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -21,3 +21,6 @@ compinit -C
 [ -f ~/.config/zsh/aliases.zsh ] && source ~/.config/zsh/aliases.zsh
 [ -f ~/.config/zsh/plugins.zsh ] && source ~/.config/zsh/plugins.zsh
 [ -f ~/.config/zsh/functions.zsh ] && source ~/.config/zsh/functions.zsh
+
+# random startup tip (loaded last so it prints after the prompt is set up)
+[ -f ~/.config/zsh/tips.zsh ] && source ~/.config/zsh/tips.zsh

--- a/private_dot_config/zsh/tips.txt
+++ b/private_dot_config/zsh/tips.txt
@@ -1,0 +1,46 @@
+# zsh 起動Tipデータ
+# 形式: category|trigger|description
+#   category : zsh / git / tool
+#   trigger  : コマンドや alias（実在するものだけ）
+#   description : 日本語1行説明
+# 区切りは「最初の2つの | だけ」。description 内の | はそのまま扱われる
+#   （例: `cmd | ask 質問` のようにパイプを含めてよい）。
+# '#' 始まりの行と空行は無視される。末尾空白は入れない。
+# メンテは Claude skill `zsh-tips` から追記するのが楽（手動追記も可）。
+
+# --- zsh: このリポジトリの alias / 関数 ---
+zsh|gb|git ブランチを fzf で選んで switch（プレビューに log graph）
+zsh|glog|git log を fzf で閲覧し、選んだコミットハッシュを出力
+zsh|gpr|gh の PR 一覧を fzf で選んで checkout
+zsh|gst|git stash を fzf で選んで差分プレビュー
+zsh|mdp|Markdown を fzf+glow でプレビューしながら閲覧（mdp [dir]）
+zsh|sshf|~/.ssh/config の Host を fzf で選んで ssh 接続
+zsh|ask|claude -p をワンショット呼び出し。`cmd | ask 質問` で文脈も渡せる
+zsh|g|ghq 管理リポジトリを fzf で選んで cd（g）
+zsh|vlast|カレントで最後のファイルを nvim で開く（vlast）
+zsh|cw|claude -w のエイリアス。作業ディレクトリ指定で起動
+zsh|vim|vim は nvim にエイリアスされている
+zsh|gwt|git worktree 一覧（gwt = git worktree list）
+zsh|gwta|worktree を追加（gwta <path> [branch]）。並行作業の起点
+zsh|gwtr|worktree を削除（gwtr <path>）。作業後の片付けに
+zsh|ma|isucon 用ベンチ一括（before-bench→bench→after-bench）
+
+# --- git / gh: ワークフロー ---
+git|git worktree|機能ごとに worktree を分ければ main を汚さず並行作業できる
+git|gh pr checks|`gh pr checks <PR#> --watch` で CI のグリーンを待てる
+git|gh pr create|`gh pr create` の本文に `Closes #XX` で Issue を自動クローズ
+git|git switch|ブランチ切替は checkout より switch が安全で明示的
+git|git restore|ファイルの変更取り消しは `git restore <file>`（checkout より明確）
+git|git stash -u|`-u` を付けると untracked ファイルも stash に含められる
+git|git commit --amend|直前コミットの修正は amend。push 前なら気軽に使える
+
+# --- tool: 便利ツールの機能紹介 ---
+tool|fzf|Ctrl-R で履歴、Ctrl-T でファイル、`**<Tab>` で補完を fzf 化
+tool|atuin|シェル履歴を SQLite で横断検索。Ctrl-R が強力になる
+tool|eza|ls は eza に置換済み。`--git` で git 状態、`--icons` でアイコン表示
+tool|starship|プロンプトは starship 製。git/言語バージョンを自動表示
+tool|ghq|`ghq get <repo>` で整理された場所に clone。`g` で素早く移動
+tool|direnv|ディレクトリ毎に環境変数を自動ロード。`.envrc` を許可するだけ
+tool|glow|Markdown をターミナルで綺麗に表示。`glow <file>` か mdp で
+tool|chezmoi|`chezmoi diff` で適用前プレビュー、`chezmoi apply` で反映
+tool|chezmoi edit|`chezmoi edit <file>` でソースを直接編集（apply は別途）

--- a/private_dot_config/zsh/tips.zsh
+++ b/private_dot_config/zsh/tips.zsh
@@ -1,0 +1,37 @@
+# zsh 起動Tip表示
+# tips.txt からランダムに1件選んで色付きで表示する。
+# 外部コマンド(shuf/awk 等)に依存せず zsh 組み込みのみで動作する。
+# データ形式は tips.txt 冒頭のコメント参照（category|trigger|description）。
+
+# カテゴリ別の色（zsh プロンプトカラー名）。未知カテゴリは既定色。
+typeset -gA _TIP_COLORS=(
+  zsh  magenta
+  git  cyan
+  tool blue
+)
+
+# tip: ランダムなTipを1件表示する。手動でも `tip` で引き直せる。
+tip() {
+  local file="${1:-$HOME/.config/zsh/tips.txt}"
+  [[ -r "$file" ]] || return 0
+
+  # コメント(#始まり)と空行を除いて配列に読み込む
+  local -a lines
+  lines=("${(@f)$(grep -vE '^[[:space:]]*(#|$)' -- "$file")}")
+  (( ${#lines} )) || return 0
+
+  # zsh 配列は1始まり。$RANDOM で1件選ぶ
+  local entry="${lines[$(( RANDOM % ${#lines} + 1 ))]}"
+
+  # category|trigger|description に分解
+  local category="${entry%%|*}"
+  local rest="${entry#*|}"
+  local trigger="${rest%%|*}"
+  local desc="${rest#*|}"
+
+  local color="${_TIP_COLORS[$category]:-white}"
+  print -P "%F{yellow}💡 tip%f %F{${color}}(${category})%f %F{green}${trigger}%f — ${desc}"
+}
+
+# インタラクティブシェルの起動時に1件表示する
+[[ -o interactive ]] && tip


### PR DESCRIPTION
## 概要

zsh 起動時に**便利コマンド/機能をランダムで1件表示**する仕組みを新規追加し、
その Tip プールを継続的に育てるための repo-local Claude skill を同梱する。

調査の結果この仕組みは未実装だったため、ゼロから作成。

## 設計（役割分離）

Claude skill は起動時に自動実行されないため、表示とメンテを分離した:

- **表示** = zsh スクリプトがデータファイルからランダム1件を出す
- **メンテ** = Claude skill `zsh-tips` が実在の alias/関数/ツールから新Tipを追記

## 変更

| ファイル | 内容 |
| --- | --- |
| `private_dot_config/zsh/tips.txt` | Tipデータ31件。`category\|trigger\|description` 形式（区切りは先頭2つの `\|` のみ、説明文に `\|` 可） |
| `private_dot_config/zsh/tips.zsh` | `tip()` 関数。純zsh(`$RANDOM`)でランダム表示・起動時自動実行。手動 `tip` で再抽選可 |
| `dot_zshrc.tmpl` | `tips.zsh` を最後に source |
| `.claude/skills/zsh-tips/SKILL.md` | repo-local の Tipメンテ用skill |

## 検証

- 表示・ランダム性・ファイル不在ガード(exit 0)
- データ健全性: フィールド不足なし / trigger 重複なし / 31件
- `make lint` ・ pre-commit パス
- `chezmoi status` で `tips.*` を新規追加(`A`)として認識、`.zshrc` diff 正常
- 外部依存なし(`shuf`/`awk` 不使用)で Linux/macOS 両対応

## 適用フロー

リポジトリ標準どおり、マージ後に `chezmoi apply` で実機反映。