### PR TITLE
fix(zsh): stop startup tip from executing example commands

### DIFF
--- a/private_dot_config/zsh/tips.zsh
+++ b/private_dot_config/zsh/tips.zsh
@@ -30,7 +30,11 @@ tip() {
   local desc="${rest#*|}"
 
   local color="${_TIP_COLORS[$category]:-white}"
-  print -P "%F{yellow}💡 tip%f %F{${color}}(${category})%f %F{green}${trigger}%f — ${desc}"
+  # 色装飾(制御下の文字列)だけプロンプト展開し、description は生で出す。
+  # starship が PROMPT_SUBST を有効化するため、print -P だと desc 内の
+  # `...` や $() がコマンドとして実行されてしまう（それを防ぐ）。
+  local fmt="%F{yellow}💡 tip%f %F{${color}}(${category})%f %F{green}${trigger}%f"
+  print -r -- "${(%)fmt} — ${desc}"
 }
 
 # インタラクティブシェルの起動時に1件表示する


### PR DESCRIPTION
## 問題

zsh 起動時のランダム tip（#100 で追加）が、tip 内容によってエラーを出していた:

```
tip:19: command not found: .envrc          # direnv tip
tip:19: parse error near '>'               # glow tip
tip:19: parse error in command substitution
```

## 根本原因

1. `private_dot_config/zsh/plugins.zsh` の `starship init zsh` が `PROMPT_SUBST` を有効化する。
2. `tips.zsh` の表示行は `print -P "...${desc}..."` で、`${desc}` 展開後に **プロンプト展開** が走る。`PROMPT_SUBST` 有効下では desc 内のバッククォートや `$()` が **コマンド置換として実行** されてしまう。
   - `` `.envrc` `` → 実行されて `command not found: .envrc`
   - `` `glow <file>` `` → `<file>` のパースで `parse error near '>'`

tips.txt は設計上 description にコード例（バッククォート・`<>`）を意図的に含むため、desc を任意テキストとして安全に表示する必要がある。

## 修正

色装飾（制御下の文字列）だけ `${(%)fmt}` フラグでプロンプト展開し、description は `print -r --` で **生出力** する。これで例コマンドが実行されず文字として表示される。zsh 組み込みのみ・サブシェル不使用の既存方針を維持。

## 検証

- 全 tip を `setopt prompt_subst` 環境で表示 → エラーなし（EXIT 0）、色も従来通り付与。
- 旧/新の差分デモで、旧実装が報告どおりの `parse error` を出し、新実装が `` `glow <file>` `` を含む全文を正しく表示することを確認。
- `make lint` 通過。