### PR TITLE
docs(claude): make zsh-tips skill self-sufficient on display safety

### DIFF
--- a/.claude/skills/zsh-tips/SKILL.md
+++ b/.claude/skills/zsh-tips/SKILL.md
@@ -27,7 +27,19 @@ category|trigger|description
 - `description`: 日本語1行の簡潔な説明
 - 区切りは**最初の2つの `|` だけ**。`description` 内に `|` を含めてよい
   （例: `zsh|ask|claude -p をワンショット。\`cmd | ask 質問\` で文脈も渡せる`）
+- `description` には `` ` `` / `<...>` / `$()` / `%` などの記号を**そのまま書いてよい**。
+  表示は `print -r --` で生出力されるため、コマンド実行もパースもされず文字として出る。
+  むしろ `` `glow <file>` `` のようなコード例を含めるのが推奨される。
 - `#` 始まりの行と空行は無視される
+
+### 表示ロジックの前提（この skill では触らないが、壊さないために知っておく）
+
+`tips.zsh` は **色装飾だけ** `${(%)fmt}` でプロンプト展開し、`description` は
+`print -r --` で**生出力**する。これを `print -P "...${desc}..."` に戻してはいけない:
+starship が `PROMPT_SUBST` を有効化しているため、description 内の `` `...` `` や
+`$()` が**コマンドとして実行されてしまう**（`` `.envrc` `` → `command not found`、
+`` `glow <file>` `` → `parse error near '>'`）。実際に起きて #101 で修正済み。
+だから上記の「記号をそのまま書いてよい」が成立する。
 
 ## ワークフロー
 
@@ -71,11 +83,24 @@ grep -vE '^[[:space:]]*(#|$)' tips.txt | awk -F'|' 'NF<3{print "BAD:",$0}'
 grep -vE '^[[:space:]]*(#|$)' tips.txt | awk -F'|' '{print $2}' | sort | uniq -d
 ```
 
-両方とも出力が空なら健全。可能なら実表示も確認:
+両方とも出力が空なら健全。さらに**実環境(starship=PROMPT_SUBST 有効)を再現して
+全 Tip を表示**し、`command not found` / `parse error` が出ないことを必ず確認する
+（`PROMPT_SUBST` を付けないテストは #101 級の回帰を見逃すので不可）:
 
 ```bash
-zsh -c 'source private_dot_config/zsh/tips.zsh; tip private_dot_config/zsh/tips.txt'
+zsh -c '
+  emulate -L zsh; setopt prompt_subst          # starship 相当
+  source private_dot_config/zsh/tips.zsh
+  for e in "${(@f)$(grep -vE "^[[:space:]]*(#|\$)" -- private_dot_config/zsh/tips.txt)}"; do
+    c="${e%%|*}"; r="${e#*|}"; t="${r%%|*}"; d="${r#*|}"
+    fmt="%F{yellow}💡 tip%f %F{${_TIP_COLORS[$c]:-white}}($c)%f %F{green}$t%f"
+    print -r -- "${(%)fmt} — $d"
+  done
+'
 ```
+
+全行がエラーなく表示され、`` ` `` や `<...>` が文字として出ていれば健全。
+途中で `command not found` / `parse error` が出たら表示ロジックが壊れている。
 
 ### 5. chezmoi フローを守る
 


### PR DESCRIPTION
#101 で修正した「起動時 tip が description 内のコマンドを実行してしまう」バグの教訓を
`zsh-tips` skill に埋め込み、**memory に頼らなくても再発防止できる**ようにする。

## 変更

`.claude/skills/zsh-tips/SKILL.md`:

1. **データ形式**に、description は `` ` ``/`<>`/`$()`/`%` をそのまま書いてよい（表示は
   `print -r --` で生出力されるため）こと、コード例を含めるのが推奨であることを明記。
2. **表示ロジックの前提**節を追加し、`print -P "...${desc}..."` に戻すと starship の
   `PROMPT_SUBST` 下で description 内コマンドが実行される（#101 の原因）ことを警告。
3. **検証ステップ**を強化: `setopt prompt_subst` で実環境を再現し全 tip を表示して
   `command not found`/`parse error` が出ないか確認する手順に変更。従来の
   `PROMPT_SUBST` 無しテストでは #101 級の回帰を見逃すため。

## 検証

- 新しい検証コマンドを実際に実行し、全 tip がエラーなく表示されることを確認。
- `make lint` 通過。

表示ロジック（tips.zsh）自体は #101 で修正済みのため変更なし。本 PR はドキュメント/手順のみ。