### PR TITLE
feat(install): add SDKMAN with Amazon Corretto latest LTS

### DIFF
--- a/.chezmoiscripts/run_once_before_install-build-deps.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_install-build-deps.sh.tmpl
@@ -10,23 +10,23 @@ if [ -f /etc/os-release ]; then
   case "${ID:-}" in
     ubuntu|debian|pop|linuxmint)
       sudo apt update
-      sudo apt install -y build-essential libssl-dev pkg-config cmake
+      sudo apt install -y build-essential libssl-dev pkg-config cmake zip unzip
       ;;
     fedora)
       sudo dnf groupinstall -y "Development Tools"
-      sudo dnf install -y openssl-devel pkg-config cmake
+      sudo dnf install -y openssl-devel pkg-config cmake zip unzip
       ;;
     rhel|centos|rocky|alma)
       sudo dnf groupinstall -y "Development Tools"
-      sudo dnf install -y openssl-devel pkg-config cmake
+      sudo dnf install -y openssl-devel pkg-config cmake zip unzip
       ;;
     arch|manjaro|endeavouros)
-      sudo pacman -Syu --noconfirm --needed base-devel openssl pkg-config cmake
+      sudo pacman -Syu --noconfirm --needed base-devel openssl pkg-config cmake zip unzip
       ;;
     # opensuse-leap, opensuse-tumbleweed, etc.
     opensuse*|sles)
       sudo zypper install -y -t pattern devel_basis
-      sudo zypper install -y libopenssl-devel pkg-config cmake
+      sudo zypper install -y libopenssl-devel pkg-config cmake zip unzip
       ;;
     *)
       log "WARNING: Unsupported distro '${ID:-unknown}'. Install a C compiler, OpenSSL dev headers, pkg-config, and cmake manually."

--- a/.chezmoiscripts/run_once_install-sdkman.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-sdkman.sh.tmpl
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+{{ includeTemplate "install-prelude.sh" }}
+
+# SDKMAN! (Java/JVM toolchain manager)
+export SDKMAN_DIR="$HOME/.sdkman"
+
+if [ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]; then
+  log "SDKMAN is already installed"
+else
+  log "Installing SDKMAN..."
+  # rcupdate=false: do not let the installer append init lines to managed
+  # rc files (~/.zshrc etc.); shell init is wired up in plugins.zsh instead.
+  curl -s "https://get.sdkman.io?rcupdate=false" | bash
+fi
+
+# Make SDKMAN non-interactive for this script and for shell startup.
+# etc/config is not chezmoi-managed, so rewriting it here is safe and avoids
+# the BSD/GNU `sed -i` portability trap.
+cat > "$SDKMAN_DIR/etc/config" <<'EOF'
+sdkman_auto_answer=true
+sdkman_auto_complete=true
+sdkman_auto_env=false
+sdkman_auto_selfupdate=false
+sdkman_selfupdate_feature=false
+sdkman_colour_enable=false
+sdkman_curl_connect_timeout=7
+sdkman_curl_max_time=10
+sdkman_debug_mode=false
+sdkman_insecure_ssl=false
+sdkman_rosetta2_compatible=false
+EOF
+
+# Load the `sdk` shell function into this script's shell.
+# shellcheck disable=SC1091
+source "$SDKMAN_DIR/bin/sdkman-init.sh"
+
+# Resolve the latest Amazon Corretto identifier. Corretto ships LTS-only
+# (8/11/17/21/25...), so the highest `-amzn` candidate is the latest LTS.
+# `|| true`: under `set -o pipefail`, an empty grep result (exit 1) would abort
+# the assignment before the explicit empty-check below; keep it a soft failure.
+java_id="$(sdk list java | awk -F'|' '{gsub(/[[:space:]]/,"",$NF); print $NF}' | grep -E '^[0-9].*-amzn$' | sort -V | tail -n1 || true)"
+
+if [ -z "$java_id" ]; then
+  log "ERROR: no Corretto (-amzn) candidate found in 'sdk list java'"
+  exit 1
+fi
+
+# Install (idempotent) and set as the default Java.
+if [ ! -d "$SDKMAN_DIR/candidates/java/$java_id" ]; then
+  log "Installing Java $java_id (Amazon Corretto, latest LTS)..."
+  sdk install java "$java_id"
+else
+  log "Java $java_id is already installed"
+fi
+
+sdk default java "$java_id"
+log "Java default set to $java_id"

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -21,6 +21,9 @@ export PATH="$VOLTA_HOME/bin:$PATH"
 export PATH="/usr/local/go/bin:$PATH"
 export PATH="$HOME/go/bin:$PATH"
 
+# SDKMAN (Java/JVM manager); init is sourced in zsh/plugins.zsh
+export SDKMAN_DIR="$HOME/.sdkman"
+
 # Atuin (shell history)
 [ -f "$HOME/.atuin/bin/env" ] && . "$HOME/.atuin/bin/env"
 

--- a/private_dot_config/zsh/plugins.zsh
+++ b/private_dot_config/zsh/plugins.zsh
@@ -12,3 +12,6 @@ fi
 
 (( $+commands[atuin] )) && eval "$(atuin init zsh)"
 (( $+commands[direnv] )) && eval "$(direnv hook zsh)"
+
+# SDKMAN (Java/JVM manager)
+[[ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]] && source "$SDKMAN_DIR/bin/sdkman-init.sh"


### PR DESCRIPTION
## Why

Java was the only major language toolchain not managed in this repo. This adds it via **SDKMAN! + Amazon Corretto (latest LTS)**, mirroring the existing pattern used for Go / Rust / Node / Python (`run_once` installer + `dot_zshenv.tmpl` env + `plugins.zsh` init).

## What

| File | Change |
|---|---|
| `.chezmoiscripts/run_once_install-sdkman.sh.tmpl` | **New.** Install SDKMAN without editing managed rc files (`?rcupdate=false`), dynamically resolve the latest Corretto, install it, and `sdk default` it |
| `dot_zshenv.tmpl` | `export SDKMAN_DIR` |
| `private_dot_config/zsh/plugins.zsh` | source `sdkman-init.sh` (interactive shells only) |
| `.chezmoiscripts/run_once_before_install-build-deps.sh.tmpl` | add `zip`/`unzip` on Linux (SDKMAN requires `unzip` to extract candidates) |

## Design notes

- **No hardcoded version.** Corretto ships LTS-only releases, so the highest `-amzn` identifier from `sdk list java` is by definition the latest LTS, resolved dynamically.
- **No rc drift.** `?rcupdate=false` stops the installer from appending init lines to chezmoi-managed `~/.zshrc`; init is wired up in `plugins.zsh` instead.
- **Robust under `set -o pipefail`.** A `|| true` guard keeps an empty candidate list a soft failure so the explicit empty-check fires (verified on macOS; `sort -V` confirmed supported).
- Works on both macOS and Linux (no OS branch).

## Verification

- `make lint` ✅
- `pre-commit run` (template-check, end-of-file, secrets) ✅
- Template renders + `bash -n` syntax check ✅
- `chezmoi diff` shows only the intended `~/.zshenv` / `~/.config/zsh/plugins.zsh` additions ✅

Actual Java install runs on `chezmoi apply` after merge (per repo standing rule; not applied yet).