### PR TITLE
feat(zsh): add fv/fcd fzf functions, relax PR rule

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -8,7 +8,7 @@ Project-specific instructions are in each project's `CLAUDE.md`.
 - **Library docs**: Use Context7 MCP before implementing anything library-specific.
 - **Worktree isolation**: Always use git worktree for feature work and bug fixes. Never work directly on main. Use `isolation: "worktree"` with the Agent tool.
 - **Agentic coding**: Prefer autonomous, agent-driven approaches — subagents, parallel execution, proactive problem-solving.
-- **PRs**: Commit and push to feature branches without asking. Always ask before creating a PR.
+- **PRs**: Commit and push to feature branches without asking. Create PRs without asking, too.
 
 ## Subagent Strategy
 

--- a/private_dot_config/zsh/functions.zsh
+++ b/private_dot_config/zsh/functions.zsh
@@ -54,6 +54,33 @@ function gst() {
   [ -n "$stash" ] && git stash show -p "$stash"
 }
 
+# Fuzzy-find a file and open it in nvim (fv [query])
+function fv() {
+  local file preview
+  if (( $+commands[bat] )); then
+    preview='bat --color=always --style=numbers --line-range :200 {}'
+  else
+    preview='cat {}'
+  fi
+  if (( $+commands[fd] )); then
+    file=$(fd --type f --hidden --exclude .git | fzf --query="$1" --preview "$preview")
+  else
+    file=$(find . -type f -not -path '*/.git/*' 2>/dev/null | fzf --query="$1" --preview "$preview")
+  fi
+  [ -n "$file" ] && nvim "$file"
+}
+
+# Fuzzy-find a directory under the tree and cd into it (fcd [dir])
+function fcd() {
+  local dir
+  if (( $+commands[fd] )); then
+    dir=$(fd --type d --hidden --exclude .git . "${1:-.}" | fzf --preview 'ls -la {}')
+  else
+    dir=$(find "${1:-.}" -type d -not -path '*/.git/*' 2>/dev/null | fzf --preview 'ls -la {}')
+  fi
+  [ -n "$dir" ] && cd "$dir"
+}
+
 # One-shot question to Claude (non-interactive, uses subscription auth, no API key)
 # Usage: ask <question>   /   <command> | ask <question>
 function ask() {

--- a/private_dot_config/zsh/tips.txt
+++ b/private_dot_config/zsh/tips.txt
@@ -18,6 +18,8 @@ zsh|sshf|~/.ssh/config の Host を fzf で選んで ssh 接続
 zsh|ask|claude -p をワンショット呼び出し。`cmd | ask 質問` で文脈も渡せる
 zsh|g|ghq 管理リポジトリを fzf で選んで cd（g）
 zsh|vlast|カレントで最後のファイルを nvim で開く（vlast）
+zsh|fv|ファイルを fzf で曖昧検索してそのまま nvim で開く（fv [query]）
+zsh|fcd|ディレクトリ階層を fzf で曖昧検索して cd（fcd [dir]）
 zsh|cw|claude -w のエイリアス。作業ディレクトリ指定で起動
 zsh|vim|vim は nvim にエイリアスされている
 zsh|gwt|git worktree 一覧（gwt = git worktree list）


### PR DESCRIPTION
## Summary

fzf 連携のシェルヘルパー2つを追加し、グローバル CLAUDE.md の PR フローを「確認なしで PR 作成」に緩和する。

### 追加した関数 (`private_dot_config/zsh/functions.zsh`)
- **`fv [query]`** — ファイルを fzf で曖昧検索してそのまま `nvim` で開く。`bat` があればプレビュー、第1引数で fzf 初期クエリ指定可。`fd`→`find` フォールバック。
- **`fcd [dir]`** — ディレクトリ階層を fzf で曖昧検索して `cd`。`.git` 等を除外。`fd`→`find` フォールバック。

既存の `vlast`（最後のファイルを開くだけ）/ `g`（ghq 専用 cd）では埋まらなかった「汎用ファイル→vim」「カレント配下→cd」を補完する。

### その他
- `tips.txt` に `fv` / `fcd` の起動 tips を2行追加
- `dot_claude/CLAUDE.md`: PR ルールを `Always ask before creating a PR.` → `Create PRs without asking, too.` に変更（feature ブランチ push を確認なしで行う既存方針と整合）

## Test plan
- [x] `make lint`（lint-json）pass
- [x] `zsh -n functions.zsh` 構文 OK
- [x] pre-commit（end-of-file / trailing-whitespace / gitleaks）pass
- [ ] マージ後 `chezmoi apply` で実機反映 → `fv` / `fcd` 手動動作確認