### PR TITLE
feat(install): add tree to Homebrew core packages

### DIFF
--- a/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
@@ -34,6 +34,7 @@ brew install \
   sheldon \
   starship \
   tmux \
+  tree \
   tree-sitter-cli \
   wget
 


### PR DESCRIPTION
## What
macOS の Homebrew コアパッケージに `tree` を追加。

## Why
ディレクトリ階層を素早く把握する基本ツールが未導入だったため。`run_once_install-homebrew` の alphabetised なリストに `tmux` と `tree-sitter-cli` の間へ挿入。

## Test
- `make lint` ✅ / chezmoi-template-check ✅
- `chezmoi execute-template` で `tree` が install リストに出力されることを確認 ✅