### PR TITLE
feat(wezterm): add OS-aware font zoom keys and tune background

### DIFF
--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -1,24 +1,64 @@
 local wezterm = require("wezterm")
+local act = wezterm.action
 local config = wezterm.config_builder()
 
+-- 実行時 OS 判定（chezmoi テンプレートではなく WezTerm 側で分岐）
+local is_macos = wezterm.target_triple:find("darwin") ~= nil
+
+-- Font
 config.font = wezterm.font("UDEV Gothic NF")
 config.font_size = 12.0
+
+-- Appearance
 config.color_scheme = "Tokyo Night"
 config.term = "xterm-256color"
 config.window_decorations = "RESIZE"
 config.enable_tab_bar = false
-config.window_background_opacity = 0.95
+config.window_background_opacity = 0.85
 config.scrollback_lines = 200
+config.automatically_reload_config = true
+if is_macos then
+  -- macOS 専用。Linux では無視されるため OS でガードしておく
+  config.macos_window_background_blur = 20
+end
+
+-- IME（Linux: fcitx）。既存設定を保持
 config.use_ime = true
 config.xim_im_name = "fcitx"
 config.ime_preedit_rendering = "Builtin"
 
+-- Keybinds
+-- 方針: pane/window/copy 等の tmux 的操作は WezTerm に置かない。
+-- ここで定義するのは「IME トグルを通すための既定無効化」と
+-- 「外部モニター対策のフォントサイズ調整」のみ。
 config.keys = {
-  {
-    key = " ",
-    mods = "CTRL",
-    action = wezterm.action.DisableDefaultAssignment,
-  },
+  -- Ctrl+Space を端末（fcitx 等）へ通すため既定割当を無効化（既存維持）
+  { key = " ", mods = "CTRL", action = act.DisableDefaultAssignment },
 }
+
+-- フォントサイズ調整（OS 別の修飾キー）
+-- macOS: Cmd(SUPER) / Linux: Ctrl+Shift
+-- "+" "_" ")" は Shift 併用時に生成される字形も拾えるよう両方登録して堅牢化
+local font_keys
+if is_macos then
+  font_keys = {
+    { key = "+", mods = "SUPER", action = act.IncreaseFontSize },
+    { key = "=", mods = "SUPER", action = act.IncreaseFontSize },
+    { key = "-", mods = "SUPER", action = act.DecreaseFontSize },
+    { key = "0", mods = "SUPER", action = act.ResetFontSize },
+  }
+else
+  font_keys = {
+    { key = "+", mods = "CTRL|SHIFT", action = act.IncreaseFontSize },
+    { key = "=", mods = "CTRL|SHIFT", action = act.IncreaseFontSize },
+    { key = "-", mods = "CTRL|SHIFT", action = act.DecreaseFontSize },
+    { key = "_", mods = "CTRL|SHIFT", action = act.DecreaseFontSize },
+    { key = "0", mods = "CTRL|SHIFT", action = act.ResetFontSize },
+    { key = ")", mods = "CTRL|SHIFT", action = act.ResetFontSize },
+  }
+end
+for _, k in ipairs(font_keys) do
+  table.insert(config.keys, k)
+end
 
 return config


### PR DESCRIPTION
## 概要

`private_dot_config/wezterm/wezterm.lua` を更新し、OS 別のフォント拡縮キーバインドと外観の微調整を追加。

## 変更内容

- **OS 判定を実行時に**: `wezterm.target_triple` で macOS / Linux を分岐（chezmoi テンプレートではなく WezTerm 側で判定）
- **フォントサイズ調整キー**: macOS = `Cmd(SUPER)` / Linux = `Ctrl+Shift`
  - `+` `=` で拡大、`-` `_` で縮小、`0` `)` でリセット
  - Shift 併用時に生成される字形（`_` `)` 等）も両方登録して堅牢化
- **外観**: `window_background_opacity` を 0.95 → 0.85 に、macOS のみ `macos_window_background_blur = 20` を有効化（Linux では無視されるため OS ガード）
- **自動リロード**: `automatically_reload_config = true` を追加
- IME（fcitx）と `Ctrl+Space` の既定無効化は既存設定を維持

## 理由

- 外部 2K モニター接続時にフォントサイズを素早く調整できるようにするため
- pane / window / copy などの操作は **tmux に分担**させる方針のため、tmux 系キーバインドは意図的に WezTerm へ追加していない

## 検証

- `make lint` パス
- `stylua --check` 整形差分なし
- `wezterm --config-file ... show-keys --lua` で構文エラーなくロード確認