### PR TITLE
feat(atuin): manage config in chezmoi and tune search

### DIFF
--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -24,9 +24,6 @@ export PATH="$HOME/go/bin:$PATH"
 # SDKMAN (Java/JVM manager); init is sourced in zsh/plugins.zsh
 export SDKMAN_DIR="$HOME/.sdkman"
 
-# Atuin (shell history)
-[ -f "$HOME/.atuin/bin/env" ] && . "$HOME/.atuin/bin/env"
-
 # uv, uvx (Python)
 [ -f "$HOME/.local/bin/env" ] && source "$HOME/.local/bin/env"
 

--- a/private_dot_config/atuin/config.toml
+++ b/private_dot_config/atuin/config.toml
@@ -1,0 +1,26 @@
+## Atuin — managed by chezmoi. Docs: https://docs.atuin.sh/configuration/config/
+
+# Enter は即実行 / Tab は編集してから実行
+enter_accept = true
+
+# 検索UIを広く・情報密に
+inline_height = 25      # 0=全画面。25行に抑えて軽く
+style = "compact"       # 余白を削った密なレイアウト
+show_preview = true     # 選択中コマンドの全文プレビュー(長い/複数行コマンド向け)
+
+# デフォルト検索モード: fuzzy(タイポ許容)。TUI内 Ctrl-S でその場切替
+search_mode = "fuzzy"
+
+# デフォルトのフィルタ範囲: global(全ホスト・全ディレクトリ)。TUI内 Ctrl-R で循環
+filter_mode = "global"
+
+# Up矢印で開いたときだけ「現在のディレクトリ」に絞る = 文脈履歴の入口
+filter_mode_shell_up_key_binding = "directory"
+
+[sync]
+records = true          # sync v2
+
+[stats]
+# `atuin stats` がサブコマンド単位で集計できるようにする(よく使うコマンド発見用)
+common_prefix = ["sudo"]
+common_subcommands = ["cargo", "git", "go", "kubectl", "docker", "npm", "pnpm", "brew"]


### PR DESCRIPTION
## Why

atuin が「インストールして `atuin init zsh` しただけ」の状態で、`~/.config/atuin/config.toml` は **chezmoi 管理外**・ほぼデフォルトだった。主訴は「**目的の履歴を探せない**」。これを解消するため config を管理下に置き、検索体験をチューニングする。

## What

- **`private_dot_config/atuin/config.toml`(新規)** — 管理化 + curated 設定
  - 肝: `filter_mode = "global"` を維持しつつ `filter_mode_shell_up_key_binding = "directory"` を追加
    - **Up矢印 = 現在のディレクトリの履歴**(文脈検索)
    - **Ctrl-R = 全体 fuzzy 検索**(TUI内 Ctrl-R で範囲循環 / Ctrl-S でモード循環)
  - `show_preview` / `style = "compact"` / `inline_height = 25` で UI を密に
  - `[stats]` の prefix/subcommand 集計で `atuin stats` をエイリアス発見に活用
  - 既存の `enter_accept` / sync v2(`records`)は維持
- **`dot_zshenv.tmpl`** — 実在しない `~/.atuin/bin/env` を source する死んだ2行を削除(atuin は brew/cargo で PATH 済み、init は `plugins.zsh`)

## 検証

- [x] `make lint`(check-toml 含む)パス
- [x] `chezmoi diff --source <worktree>` で config 置換・zshenv 差分を確認(`enter_accept`/`records` 保持を確認）
- [ ] マージ後に `chezmoi apply` → 新シェルで Up=ディレクトリ履歴 / Ctrl-R=全体検索を動作確認

> apply はマージ後に実施(リポジトリのワークフロー規約に従う)。