### PR TITLE
docs(claude): require self-running apply after merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,12 @@ during review with `chezmoi diff` (use `--source <worktree>` to preview from a
 feature worktree). Apply only after merge, so the live machine always reflects
 merged, reviewed state.
 
+**Standing rule:** Once a PR is merged, run the apply step yourself — do not
+hand it back to the user. Fast-forward `main` (`git pull --ff-only`), confirm
+with `chezmoi diff -- <changed paths>`, then `chezmoi apply -- <changed paths>`
+scoped to the files this PR touched (so unrelated live drift is never swept in),
+and verify `chezmoi diff` is empty afterward.
+
 ## PR-Driven Development (Required)
 
 All changes go through PRs. Never commit directly to main.


### PR DESCRIPTION
## Why

マージ後の `chezmoi apply` をユーザーに手渡しで終わらせず、エージェントが一連の流れ(マージ→適用)として自分で実行してほしい、という運用方針を明文化する。個人メモではなく checked-in の CLAUDE.md に置くことで、リポジトリのワークフロー規約として共有する。

## What

`## Workflow` に standing rule を1つ追加:

> Once a PR is merged, run the apply step yourself — do not hand it back to the user. Fast-forward `main` → `chezmoi diff -- <changed paths>` で確認 → 変更ファイルに絞って `chezmoi apply -- <changed paths>` → 後で `chezmoi diff` が空になることを確認。

- 既存の「マージ前 apply 禁止」ルールは維持
- 適用範囲を変更ファイルに絞ることで、無関係なライブ drift を巻き込まない点も明記