### PR TITLE
feat(claude,tmux,fonts): externalize Bedrock env, fix tmux bg/plugins, add UDEV Gothic NF

### DIFF
--- a/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
@@ -38,6 +38,9 @@ brew install \
   tree-sitter-cli \
   wget
 
+# Fonts via Homebrew Cask
+brew install --cask font-udev-gothic-nf
+
 # Go tools not available via Homebrew
 if ! command -v memo >/dev/null 2>&1; then
   log "Installing memo..."

--- a/.chezmoiscripts/run_onchange_after_install-tmux-plugins.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_install-tmux-plugins.sh.tmpl
@@ -12,8 +12,9 @@ fi
 
 TPM_DIR="${HOME}/.tmux/plugins/tpm"
 if [ ! -x "${TPM_DIR}/bin/install_plugins" ]; then
-  log "ERROR: TPM not found at ${TPM_DIR}. .chezmoiexternal.toml should clone it before this script runs."
-  exit 1
+  log "TPM not found at ${TPM_DIR}. Cloning..."
+  mkdir -p "${HOME}/.tmux/plugins"
+  git clone --depth=1 https://github.com/tmux-plugins/tpm.git "${TPM_DIR}"
 fi
 
 log "Installing tmux plugins via TPM..."

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -156,6 +156,18 @@
   },
   "env": {
     "CLAUDE_CODE_ENABLE_AUTO_MODE": "1"
+    {{- if hasKey . "bedrock_base_url" }},
+    "ANTHROPIC_BEDROCK_BASE_URL": "{{ .bedrock_base_url }}",
+    "AWS_BEARER_TOKEN_BEDROCK": "{{ .bedrock_token }}",
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
+    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+    "OTEL_METRICS_EXPORTER": "otlp",
+    "OTEL_LOGS_EXPORTER": "otlp",
+    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+    "OTEL_EXPORTER_OTLP_ENDPOINT": "{{ .otel_endpoint }}",
+    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization={{ .bedrock_token }}"
+    {{- end }}
   },
   "language": "japanese",
   "preferredNotifChannel": "auto",

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -109,7 +109,7 @@ run '~/.tmux/plugins/tpm/tpm'
 # -----------------------
 # Pane Style (after TPM to override Catppuccin)
 # -----------------------
-set -g window-style 'bg=#24273a'
-set -g window-active-style 'bg=#1e1e2e'
+set -g window-style 'bg=default'
+set -g window-active-style 'bg=default'
 set -g pane-border-style 'fg=#6c7086'
 set -g pane-active-border-style 'fg=#89b4fa,bold'


### PR DESCRIPTION
## Summary

- **claude**: `settings.json` を chezmoi テンプレート化。Bedrock/OTEL 認証情報を `~/.config/chezmoi/chezmoi.toml`（Git 管理外）に隔離し、他マシンでは該当ブロックをスキップ
- **tmux**: プラグインスクリプトを `run_onchange_after_` にリネームしてファイル展開後実行を保証、TPM 未インストール時に自己 clone を追加、ウィンドウ背景を `bg=default` に変更してターミナル透過を有効化
- **fonts**: `font-udev-gothic-nf` を Homebrew Cask でインストール

## Security

- 会社固有の URL・トークンはいずれもリポジトリに含まれていません
- `dot_claude/CLAUDE.md` は `origin/main` と同一状態（Company PC Setup セクション除外済み）
- gitleaks でリーク検出なし

## Test plan

- [ ] `git diff origin/main HEAD -- dot_claude/CLAUDE.md` が空であることを確認
- [ ] CI (pre-commit checks) がパスすること