### PR TITLE
chore(gh): remove hosts.yml from chezmoi management

### DIFF
--- a/private_dot_config/gh/private_hosts.yml
+++ b/private_dot_config/gh/private_hosts.yml
@@ -1,5 +1,0 @@
-github.com:
-    git_protocol: ssh
-    users:
-        edge2992:
-    user: edge2992


### PR DESCRIPTION
## Summary

- `private_dot_config/gh/private_hosts.yml` を chezmoi の管理対象から削除
- `gh auth login` がこのファイルを書き換えるため、ログインのたびに chezmoi drift が発生していた
- 認証状態はマシン固有で、バージョン管理すべきでない
- `~/.config/gh/hosts.yml`（ライブファイル）は削除しない

`private_config.yml`（エディタ・エイリアス等の設定）は引き続き管理する。

## Test plan

- [ ] `chezmoi diff` に `hosts.yml` が現れないことを確認
- [ ] `~/.config/gh/hosts.yml` が存在し続けることを確認
- [ ] `gh auth status` が正常に動作することを確認