### PR TITLE
feat(nvim): enable catppuccin transparent background

### DIFF
--- a/private_dot_config/nvim/lua/edgissa/plugins/colorscheme.lua
+++ b/private_dot_config/nvim/lua/edgissa/plugins/colorscheme.lua
@@ -5,6 +5,7 @@ return {
   config = function()
     require("catppuccin").setup({
       flavour = "mocha",
+      transparent_background = true,
       integrations = {
         cmp = true,
         gitsigns = true,


### PR DESCRIPTION
## Summary

- Add `transparent_background = true` to the catppuccin setup in `colorscheme.lua`

## Background

The WezTerm → tmux → Neovim transparency chain was broken because catppuccin was painting a solid `#1e1e2e` background over the terminal canvas. Even with WezTerm background opacity set and tmux configured to pass transparency through, Neovim's colorscheme would override it with an opaque fill.

Setting `transparent_background = true` tells catppuccin to emit `Normal` highlight groups with no background (`bg = NONE`), so the terminal's own transparency/background image shows through instead.

## Test plan

- [ ] Run `make nvim-check` — passes (25 files, 0 errors)
- [ ] `chezmoi diff` shows the single-line addition
- [ ] After `chezmoi apply` (post-merge): open Neovim inside WezTerm with background opacity < 1.0 and confirm the terminal background is visible through the editor