### PR TITLE
feat(claude): automate JSON-tmpl verification + tmpl-aware sync

### DIFF
--- a/.claude/skills/chezmoi-claude-sync/SKILL.md
+++ b/.claude/skills/chezmoi-claude-sync/SKILL.md
@@ -58,6 +58,33 @@ untracked files for the user's awareness (e.g. a hand-written
 `agents/foo.md`), but do not `chezmoi add` them unless the user explicitly
 asks to start managing that file.
 
+**JSON configs are noisy under raw `chezmoi diff`.** Claude Code rewrites
+`settings.json` and reorders its keys, so `chezmoi diff` shows large
+reorder/reformat hunks that are *not* real content changes. To see the true
+semantic delta, compare the rendered source against the live file with sorted
+keys:
+
+```bash
+diff <(chezmoi cat ~/.claude/settings.json | jq -S .) \
+     <(jq -S . ~/.claude/settings.json)
+```
+
+`chezmoi cat` renders the source (templates included), and `jq -S` sorts keys,
+so the only lines that survive are genuine additions/removals. Use this to drive
+classification; treat the raw-diff reordering as DISCARD noise that `chezmoi
+apply` will normalize after merge.
+
+**Know whether the source is a template.** Resolve it once per path:
+
+```bash
+chezmoi source-path ~/.claude/settings.json   # → …/dot_claude/settings.json.tmpl
+```
+
+A `.tmpl` suffix means the source contains Go-template logic (e.g.
+`settings.json.tmpl` guards its `env` block with
+`{{- if hasKey . "bedrock_base_url" }}`). This changes how you ADOPT — see
+step 5.
+
 ### 3. Examine each diff and classify
 
 Read every hunk in `chezmoi diff ~/.claude` and sort each change into one of:
@@ -88,9 +115,17 @@ ask if something is ambiguous enough that guessing wrong would be costly.
 
 After confirmation, act under `$SRC`:
 
-- **ADOPT** → `chezmoi re-add <path>` (updates the source from the live target
-  for already-managed files). `re-add` will not introduce new files, which keeps
-  scope honest.
+- **ADOPT (non-template source)** → `chezmoi re-add <path>` (updates the source
+  from the live target for already-managed files). `re-add` will not introduce
+  new files, which keeps scope honest.
+- **ADOPT (`.tmpl` source)** → **never `chezmoi re-add`.** `re-add` overwrites the
+  source with the *rendered* output, destroying the `{{ }}` template logic (e.g.
+  it would collapse `settings.json.tmpl`'s bedrock `{{- if … }}` branch into
+  whatever this machine happened to render). Instead hand-edit the source
+  `.tmpl` (e.g. `$SRC/dot_claude/settings.json.tmpl`) to add *only* the adopted
+  change, leaving every `{{ }}` block untouched — exactly like the PARTIAL case
+  below. The normalized `diff <(chezmoi cat …) <(jq -S …)` from step 2 tells you
+  precisely which line(s) to add.
 - **PARTIAL** → do *not* `re-add` the whole file. Open the source file
   (e.g. `$SRC/dot_claude/settings.json`) and hand-edit it so it contains the
   ADOPT hunks and *omits* the DISCARD hunks. This is the conflict resolution —
@@ -108,9 +143,15 @@ After confirmation, act under `$SRC`:
   reflects exactly the intended changes and nothing else (no noise files crept
   in; the expanded `.chezmoiignore` should prevent that).
 - `chezmoi diff ~/.claude` again — the remaining diff should be only the DISCARD
-  items you deliberately left, or empty.
-- Run `make lint` (use `make lint-json` if you touched `settings.json`) from
-  `$SRC` so the change passes the same checks CI will run.
+  items you deliberately left, or the cosmetic key-reorder noise (which `chezmoi
+  apply` normalizes after merge); the normalized `diff <(chezmoi cat …) <(jq -S …)`
+  should now show no genuine content delta.
+- If you hand-edited a `.tmpl`, run `make lint-tmpl` (or
+  `scripts/check-json-tmpl.sh`) from `$SRC` to prove the template still renders
+  to valid JSON on *both* branches (default and bedrock) — a stray comma is easy
+  to introduce and `chezmoi diff` alone will not catch it.
+- Run `make lint` (which now runs `lint-json` + `lint-tmpl`) from `$SRC` so the
+  change passes the same checks CI will run.
 
 ### 7. Ship it (PR-driven)
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,9 @@ repos:
         files: \.tmpl$
         exclude: ^\.chezmoi\.yaml\.tmpl$
         types: [file]
+      - id: json-tmpl-validate
+        name: validate rendered JSON templates
+        entry: scripts/check-json-tmpl.sh
+        language: system
+        files: \.json\.tmpl$
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ Never rename chezmoi source files without understanding the naming convention im
 ```bash
 make lint          # Run all lints — required before committing
 make lint-json     # JSON syntax only
+make lint-tmpl     # Render *.json.tmpl and validate the output is valid JSON
 make nvim-check    # Verify Neovim Lua config (stylua + headless load)
 ```
 
@@ -36,7 +37,7 @@ When changing Neovim config, follow the verification flow in
 
 ## Pre-commit Hooks
 
-Configured in `.pre-commit-config.yaml`: check-toml, check-yaml, end-of-file-fixer, trailing-whitespace, shellcheck, stylua, gitleaks, chezmoi-template-check.
+Configured in `.pre-commit-config.yaml`: check-toml, check-yaml, end-of-file-fixer, trailing-whitespace, shellcheck, stylua, gitleaks, chezmoi-template-check, json-tmpl-validate.
 
 Never bypass with `--no-verify` — investigate and fix failures.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: lint lint-json nvim-check
+.PHONY: lint lint-json lint-tmpl nvim-check
 
-lint: lint-json
+lint: lint-json lint-tmpl
 
 NVIM_SRC := private_dot_config/nvim
 STYLUA := $(shell command -v stylua 2>/dev/null || echo $(HOME)/.local/share/nvim/mason/bin/stylua)
@@ -30,3 +30,6 @@ lint-json:
 		fi; \
 	done; \
 	[ $$fail -eq 0 ] && echo "All JSON files valid." || (echo "JSON validation failed." && exit 1)
+
+lint-tmpl:
+	@scripts/check-json-tmpl.sh

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -172,5 +172,6 @@
   "language": "japanese",
   "preferredNotifChannel": "auto",
   "editorMode": "vim",
-  "tui": "fullscreen"
+  "tui": "fullscreen",
+  "skipWorkflowUsageWarning": true
 }

--- a/scripts/check-json-tmpl.sh
+++ b/scripts/check-json-tmpl.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Validate that every *.json.tmpl renders to syntactically valid JSON.
+#
+# The repo's existing chezmoi-template-check hook only proves a template
+# *renders* without error; it does not prove the rendered output is valid
+# JSON (a stray trailing comma in a conditional branch would slip through).
+# This script renders each template with deterministic, machine-independent
+# data and parses the result with python's json module.
+#
+# settings.json.tmpl additionally has a `{{ if hasKey . "bedrock_base_url" }}`
+# branch, so it is rendered twice: once without bedrock data (default branch)
+# and once with mock bedrock data (the comma-heavy conditional branch).
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Empty data config -> deterministic "default" render, independent of the
+# machine's real ~/.config/chezmoi/chezmoi.toml and CI's lack thereof.
+empty_cfg="$tmpdir/empty.toml"
+printf '[data]\n' >"$empty_cfg"
+
+# Mock bedrock data -> exercises the hasKey branch in settings.json.tmpl.
+bedrock_cfg="$tmpdir/bedrock.toml"
+cat >"$bedrock_cfg" <<'EOF'
+[data]
+bedrock_base_url = "https://example.invalid/bedrock"
+bedrock_token = "test-token"
+otel_endpoint = "https://example.invalid/otel"
+EOF
+
+# render <config> <template> <label>
+render() {
+  local cfg="$1" tmpl="$2" label="$3" out
+  if ! out="$(chezmoi execute-template --config "$cfg" --source . <"$tmpl" 2>&1)"; then
+    echo "  FAIL: $tmpl ($label) — template did not render:" >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  fi
+  if ! printf '%s' "$out" | python3 -c 'import json,sys; json.load(sys.stdin)' 2>/dev/null; then
+    echo "  FAIL: $tmpl ($label) — rendered output is not valid JSON:" >&2
+    printf '%s\n' "$out" >&2
+    return 1
+  fi
+  echo "  OK: $tmpl ($label)"
+}
+
+echo "Validating rendered JSON templates..."
+fail=0
+while IFS= read -r tmpl; do
+  render "$empty_cfg" "$tmpl" "default" || fail=1
+  if [ "$(basename "$tmpl")" = "settings.json.tmpl" ]; then
+    render "$bedrock_cfg" "$tmpl" "bedrock" || fail=1
+  fi
+done < <(find . -name '*.json.tmpl' -not -path './.git/*' | sort)
+
+if [ "$fail" -eq 0 ]; then
+  echo "All rendered JSON templates valid."
+else
+  echo "JSON template validation failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Why

`/chezmoi-claude-sync` を実行した際、ライブ `~/.claude/settings.json` のドリフト調査から3つの課題が判明したため一括対応する。

1. **ドリフト**: ライブに `skipWorkflowUsageWarning: true` があり、ソーステンプレートに無かった(他のdiffはClaude Codeのキー並び替えノイズで、jq正規化比較すると実差はこの1点のみ)。
2. **tmpl検証が手薄**: `make lint-json` は `*.json` のみ。pre-commit の `chezmoi-template-check` は「renderが通るか」だけで、**出力が有効なJSONかを検証していない**。壊れたJSONを吐いても検出できなかった。
3. **スキルがtmpl非対応**: `chezmoi-claude-sync` はADOPT時に `chezmoi re-add` を指示するが、`settings.json` のソースは `.tmpl`(`env` に `{{- if hasKey . "bedrock_base_url" }}` を含む)。re-add すると `{{ }}` が破壊される。

## What

- **`chore(claude)`**: `settings.json.tmpl` に `skipWorkflowUsageWarning: true` を手編集で追加(re-add不使用、テンプレートブロック保全)。
- **`feat(install)`**: `scripts/check-json-tmpl.sh` を新設。全 `*.json.tmpl` を決定論的データでrenderしJSON妥当性を検証。`settings.json.tmpl` は **default分岐とbedrock分岐の両方**を検証。`make lint`(新 `lint-tmpl` ターゲット)と pre-commit `json-tmpl-validate` フックに組み込み、**毎回自動実行**。
- **`docs(claude)`**: `chezmoi-claude-sync` スキルをtmpl対応に更新。`.tmpl` ソースは re-add 禁止・手編集、`chezmoi cat | jq -S` での正規化比較、`make lint-tmpl` 検証を明記。
- **`docs`**: `CLAUDE.md` に `lint-tmpl` / `json-tmpl-validate` を記載。

## Verification

- `make lint-tmpl` → default/bedrock 両分岐 VALID JSON
- 末尾カンマを注入 → `make lint-tmpl` が **FAIL**(検知機能の証明)→ 復元でpass
- `make lint`(json+tmpl)/ shellcheck / pre-commit `json-tmpl-validate` 全pass
- 正規化比較でドリフト解消を確認、テンプレート `{{ }}` ブロック6個無傷