### PR TITLE
fix(tmux): clear macOS notch in fullscreen, drop session restore

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -36,7 +36,7 @@ bind r source-file ~/.tmux.conf \; display "Config Reloaded!"
 # -----------------------
 set -g status-position top
 set -g status-interval 1
-set -g status-justify absolute-centre
+set -g status-justify left
 set -g status-left-length 100
 set -g status-right-length 120
 set -g focus-events on
@@ -96,13 +96,9 @@ set -g @catppuccin_date_time_text "%Y-%m-%d %H:%M"
 # Plugin Config
 # -----------------------
 set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-resurrect'
-set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'thewtex/tmux-mem-cpu-load'
 set -g @plugin 'catppuccin/tmux'
-
-set -g @continuum-restore 'on'
 
 run '~/.tmux/plugins/tpm/tpm'
 


### PR DESCRIPTION
## What

- **ノッチ回避**: `status-justify absolute-centre` → `left`。WezTerm の `option+enter`（simple fullscreen）は
  ノッチ／メニューバーの予約領域を無視して全画面描画するため、画面最上段・中央が隠れる。ウィンドウ一覧が
  `absolute-centre` でノッチ直下に固定されていたのを左寄せにし、status-left/right も元から圏外なので、
  読みたい要素すべてがノッチを避ける。
- **継続セッション削除**: `tmux-resurrect` / `tmux-continuum` と `@continuum-restore 'on'` を削除。
  セッションは使い回さないため自動保存・復元は不要。

## Why

全画面のときだけ tmux バーがカメラ（ノッチ）に被って上が切れていた。普段のウィンドウ表示は無問題。
第一原理での根本原因は simple fullscreen のノッチ侵入 × バーの中央寄せ配置。WezTerm の即時フルスクリーン感は
維持したいので、tmux 側の最小変更（左寄せ）で対処する。

## Notes

- TPM は `@plugin` 行から導入するため、行削除で十分。既存の resurrect/continuum ディレクトリは
  `~/.tmux/plugins/` に残るがロードされなくなる（自動保存も停止）。完全削除は任意で TPM clean。
- WezTerm 設定 (`wezterm.lua`) は変更なし。
- バーの「細さ」はノッチ回避で大半が解消する想定のため今回は 1 行のまま。

## Test

- `make lint` 緑
- マージ後 `chezmoi apply -- ~/.tmux.conf` → 再読込し、`tmux show-options -g status-justify` が `left`、
  `@continuum-restore` が未設定、全画面でバーがノッチに被らないことを目視確認。