### PR TITLE
feat(claude): add AWS MCP and uv rules to CLAUDE.md and settings

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -9,6 +9,8 @@ Project-specific instructions are in each project's `CLAUDE.md`.
 - **Worktree isolation**: Always use git worktree for feature work and bug fixes. Never work directly on main. Use `isolation: "worktree"` with the Agent tool.
 - **Agentic coding**: Prefer autonomous, agent-driven approaches — subagents, parallel execution, proactive problem-solving.
 - **PRs**: Commit and push to feature branches without asking. Create PRs without asking, too.
+- **AWS resources**: When viewing or querying AWS resources, always use the `mcp__aws-mcp__aws___call_aws` MCP tool.
+- **Python scripts**: Always use `uv` to run Python scripts (`uv run script.py`). Use `uv` for package management instead of `pip`/`python`.
 
 ## Subagent Strategy
 

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -74,7 +74,20 @@
       "mcp__plugin_context7_context7__query-docs",
       "mcp__plugin_context7_context7__resolve-library-id",
       "mcp__serena",
-      "mcp__playwright"
+      "mcp__playwright",
+      "mcp__aws-docs__read_documentation",
+      "mcp__aws-docs__read_sections",
+      "mcp__aws-docs__recommend",
+      "mcp__aws-docs__search_documentation",
+      "mcp__aws-mcp__aws___call_aws",
+      "mcp__aws-mcp__aws___recommend",
+      "mcp__aws-mcp__aws___search_documentation",
+      "mcp__aws-mcp__aws___suggest_aws_commands",
+      "mcp__aws-knowledge-mcp-server__aws___search_documentation",
+      "mcp__aws-knowledge-mcp-server__aws___read_documentation",
+      "mcp__aws-knowledge-mcp-server__aws___recommend",
+      "mcp__aws-knowledge-mcp-server__aws___list_regions",
+      "mcp__aws-knowledge-mcp-server__aws___get_regional_availability"
     ],
     "deny": [
       "Bash(sudo:*)",


### PR DESCRIPTION
## Summary

- Add rule to always use `mcp__aws-mcp__aws___call_aws` MCP tool when viewing or querying AWS resources
- Add rule to always use `uv` for running Python scripts and package management instead of `pip`/`python`
- Add 13 AWS MCP permission entries to `settings.json.tmpl` allow list (`mcp__aws-docs__*`, `mcp__aws-mcp__*`, `mcp__aws-knowledge-mcp-server__*`)

## Test plan

- [x] `make lint` passes (JSON validation + rendered JSON template validation)
- [x] Pre-commit hooks pass (gitleaks, chezmoi-template-check, json-tmpl-validate)