### PR TITLE
fix(wezterm): use native fullscreen to clear macOS notch

### DIFF
--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -20,7 +20,7 @@ config.automatically_reload_config = true
 if is_macos then
   -- macOS 専用。Linux では無視されるため OS でガードしておく
   config.macos_window_background_blur = 20
-  config.native_macos_fullscreen_mode = true  -- safe area を考慮した native fullscreen を使用
+  config.native_macos_fullscreen_mode = true -- safe area を考慮した native fullscreen を使用
 end
 
 -- IME（Linux: fcitx）。既存設定を保持

--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -20,6 +20,7 @@ config.automatically_reload_config = true
 if is_macos then
   -- macOS 専用。Linux では無視されるため OS でガードしておく
   config.macos_window_background_blur = 20
+  config.native_macos_fullscreen_mode = true  -- safe area を考慮した native fullscreen を使用
 end
 
 -- IME（Linux: fcitx）。既存設定を保持


### PR DESCRIPTION
## 問題

WezTerm のデフォルト（simple）フルスクリーンは macOS の safe area exclusion zone を無視するため、フルスクリーン時に以下の症状が発生する:

- notch 周辺（画面上部）が黒く潰れて表示される
- 下部のコンテンツが一部隠れる

## 修正

`native_macos_fullscreen_mode = true` を `is_macos` ブロックに追加。

macOS ネイティブのフルスクリーン API を使用することで safe area を正しく考慮した表示となり、notch 問題が解消される。

## 変更ファイル

- `private_dot_config/wezterm/wezterm.lua`: `is_macos` ブロックに `native_macos_fullscreen_mode = true` を追加