### PR TITLE
chore(claude): sync model[1m] and voice settings

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -105,7 +105,7 @@
     "ask": ["Bash(gh pr create:*)", "Bash(gh pr merge:*)"],
     "defaultMode": "plan"
   },
-  "model": "opus",
+  "model": "opus[1m]",
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
   "enableAllProjectMcpServers": true,
@@ -186,5 +186,10 @@
   "preferredNotifChannel": "auto",
   "editorMode": "vim",
   "tui": "fullscreen",
+  "voice": {
+    "enabled": true,
+    "mode": "hold"
+  },
+  "voiceEnabled": true,
   "skipWorkflowUsageWarning": true
 }


### PR DESCRIPTION
## Summary

`~/.claude/settings.json` の直接編集で生じたドリフトを chezmoi ソース
`dot_claude/settings.json.tmpl` へ選択的に反映（衝突解決）。ソースは `.tmpl`
のため `chezmoi re-add` を使わず手編集した。

| 変更 | 分類 |
| --- | --- |
| `model`: `opus` → `opus[1m]`（1M-context 版を既定に） | ADOPT |
| `voice`（hold mode）/ `voiceEnabled` トグル追加 | ADOPT |
| AWS MCP 許可エントリ（live 側に無い） | DISCARD（apply 待ちの source 先行。e380782 で追加済み・未 apply のためソースは変更せず） |

## Verification

- `make lint`（lint-json + lint-tmpl）グリーン
- `.tmpl` は default / bedrock 両分岐で有効な JSON にレンダリング
- 正規化差分（`chezmoi cat` vs live）で model / voice は解消、残差は DISCARD の AWS エントリのみ

## Follow-up

マージ後に `chezmoi apply -- ~/.claude/settings.json` を実行し live を同期
（AWS エントリもこの apply で反映される）。