### PR TITLE
feat(claude): add ccgate permission-request hook with gpt-5-mini

### DIFF
--- a/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
@@ -46,4 +46,9 @@ if ! command -v memo >/dev/null 2>&1; then
   log "Installing memo..."
   go install github.com/mattn/memo@latest
 fi
+
+if ! command -v ccgate >/dev/null 2>&1; then
+  log "Installing ccgate..."
+  go install github.com/tak848/ccgate@latest
+fi
 {{ end }}

--- a/.chezmoiscripts/run_once_install-linux-packages.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-linux-packages.sh.tmpl
@@ -73,4 +73,9 @@ if ! command -v dw >/dev/null 2>&1; then
   log "Installing dw..."
   go install github.com/edge2992/dw@latest
 fi
+
+if ! command -v ccgate >/dev/null 2>&1; then
+  log "Installing ccgate..."
+  go install github.com/tak848/ccgate@latest
+fi
 {{ end }}

--- a/.chezmoiscripts/run_onchange_install-go-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_install-go-tools.sh.tmpl
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+{{ includeTemplate "install-prelude.sh" }}
+
+# go install で管理する Go ツール（run_once_ 実行済みマシンへの追加対応）
+if ! command -v ccgate >/dev/null 2>&1; then
+  log "Installing ccgate..."
+  go install github.com/tak848/ccgate@latest
+fi

--- a/dot_claude/ccgate.jsonnet
+++ b/dot_claude/ccgate.jsonnet
@@ -1,0 +1,7 @@
+{
+  provider: {
+    name: 'openai',
+    model: 'gpt-5-mini',
+    base_url: 'https://api.ai.public.rakuten-it.com/openai/v1',
+  },
+}

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -142,6 +142,17 @@
           }
         ]
       }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ccgate claude"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {
@@ -179,7 +190,8 @@
     "OTEL_LOGS_EXPORTER": "otlp",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "{{ .otel_endpoint }}",
-    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization={{ .bedrock_token }}"
+    "OTEL_EXPORTER_OTLP_HEADERS": "Authorization={{ .bedrock_token }}",
+    "CCGATE_OPENAI_API_KEY": "{{ .bedrock_token }}"
     {{- end }}
   },
   "language": "japanese",


### PR DESCRIPTION
## Summary

- `dot_claude/ccgate.jsonnet` を新規作成: Rakuten AI ゲートウェイ経由で gpt-5-mini を使う OpenAI プロバイダー設定
- `settings.json.tmpl` に `PermissionRequest` フックを追加: 各パーミッションリクエスト時に `ccgate claude` を実行
- `env` ブロックに `CCGATE_OPENAI_API_KEY` を追加（`bedrock_token` から設定）
- `run_once_install-homebrew.sh.tmpl` / `run_once_install-linux-packages.sh.tmpl` に ccgate インストールを追加
- `run_onchange_install-go-tools.sh.tmpl` を新規作成: 既存マシンでも ccgate を自動インストール

## Test plan

- [ ] `make lint` が通ること（lint-tmpl でテンプレート JSON バリデーションも確認）
- [ ] `chezmoi diff` で差分を確認
- [ ] ccgate が `go install` で正常インストールされること
- [ ] PermissionRequest フックが Claude Code で動作すること