### PR TITLE
feat(claude): restrict ccgate PermissionRequest hook to work env only

### DIFF
--- a/dot_claude/modify_settings.json.tmpl
+++ b/dot_claude/modify_settings.json.tmpl
@@ -20,7 +20,8 @@ RESULT=$(printf '%s' "$RESULT" | jq \
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_EXPORTER_OTLP_ENDPOINT": $otel,
     "OTEL_EXPORTER_OTLP_HEADERS": ("Authorization=" + $token)
-  }')
+  } |
+  .hooks.PermissionRequest = [{"matcher": "", "hooks": [{"type": "command", "command": "ccgate claude"}]}]')
 {{- end }}
 
 {{- if hasKey . "extra_marketplace_url" }}


### PR DESCRIPTION
## Summary
- ccgate の `PermissionRequest` hook を会社環境（`bedrock_base_url` が存在する場合）のみに注入するよう設定
- `modify_settings.json.tmpl` の bedrock ブロック内 jq フィルタに `.hooks.PermissionRequest` フィールドを追加

## Test plan
- [ ] `make lint` が通ること（`make lint-tmpl` で bedrock/work プロファイルの JSON が valid であること）
- [ ] `chezmoi diff` で bedrock 環境時のみ `hooks.PermissionRequest` が設定されることを確認