### PR TITLE
feat(claude): add skipDangerousModePermissionPrompt to base settings

### DIFF
--- a/.chezmoitemplates/claude-settings-base.json
+++ b/.chezmoitemplates/claude-settings-base.json
@@ -217,5 +217,6 @@
     "mode": "hold"
   },
   "voiceEnabled": true,
-  "skipWorkflowUsageWarning": true
+  "skipWorkflowUsageWarning": true,
+  "skipDangerousModePermissionPrompt": true
 }


### PR DESCRIPTION
## Summary
- `.chezmoitemplates/claude-settings-base.json` に `skipDangerousModePermissionPrompt: true` を追加
- `skipWorkflowUsageWarning: true` の直後に挿入

## Test plan
- [ ] `make lint` が通ることを確認済み
- [ ] `chezmoi diff` で差分を確認