### PR TITLE
feat(claude): merge company settings overlay via jsonnet

### DIFF
--- a/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-homebrew.sh.tmpl
@@ -51,4 +51,9 @@ if ! command -v ccgate >/dev/null 2>&1; then
   log "Installing ccgate..."
   go install github.com/tak848/ccgate@latest
 fi
+
+if ! command -v jsonnet >/dev/null 2>&1; then
+  log "Installing jsonnet..."
+  go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+fi
 {{ end }}

--- a/.chezmoiscripts/run_once_install-linux-packages.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-linux-packages.sh.tmpl
@@ -78,4 +78,9 @@ if ! command -v ccgate >/dev/null 2>&1; then
   log "Installing ccgate..."
   go install github.com/tak848/ccgate@latest
 fi
+
+if ! command -v jsonnet >/dev/null 2>&1; then
+  log "Installing jsonnet..."
+  go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+fi
 {{ end }}

--- a/.chezmoiscripts/run_onchange_install-go-tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_install-go-tools.sh.tmpl
@@ -7,3 +7,8 @@ if ! command -v ccgate >/dev/null 2>&1; then
   log "Installing ccgate..."
   go install github.com/tak848/ccgate@latest
 fi
+
+if ! command -v jsonnet >/dev/null 2>&1; then
+  log "Installing jsonnet..."
+  go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+fi

--- a/.claude/skills/chezmoi-claude-sync/SKILL.md
+++ b/.claude/skills/chezmoi-claude-sync/SKILL.md
@@ -34,9 +34,9 @@ plain template. The source is `dot_claude/modify_settings.json.tmpl`, which:
 
 1. Starts from `.chezmoitemplates/claude-settings-base.json` (the universal
    settings — models, hooks, permissions, env vars that apply on every machine).
-2. Conditionally injects work-specific env vars (Bedrock endpoint, OTEL config)
-   when the chezmoi data keys `bedrock_base_url` / `otel_endpoint` are present
-   in `~/.config/chezmoi/chezmoi.toml`.
+2. If a company overlay is present (see the contract below), merges it on top
+   with jsonnet. Machines without the overlay get the base verbatim, so the
+   public repo carries no company-specific keys at all.
 
 **Key consequence:** `chezmoi source-path ~/.claude/settings.json` returns
 `…/dot_claude/modify_settings.json.tmpl`. This is the modify **script** — do
@@ -44,9 +44,25 @@ NOT `chezmoi re-add` it. The actual settings content lives in
 `.chezmoitemplates/claude-settings-base.json`. That is the file you edit to
 adopt universal settings changes.
 
-**Note on ccgate:** `dot_claude/ccgate.jsonnet` is no longer chezmoi-managed
-(forgotten in PR #124). Do not attempt to re-add or manage it. It is
-work-specific and manually deployed outside chezmoi.
+**Note on ccgate:** ccgate config (`~/.claude/ccgate.jsonnet`) is
+company-scope and belongs to the company overlay repo, not chezmoi. Do not
+attempt to re-add or manage it here.
+
+### Company overlay contract
+
+- Entry point: `$OVERLAY_DIR/overlay.jsonnet`, where `$OVERLAY_DIR` defaults
+  to `~/.config/claude-overlay` (a private company repo cloned there;
+  overridable via the chezmoi data key `claude_overlay_dir`).
+- Signature: `function(base, data) base + { ... }` — `base` is the rendered
+  `claude-settings-base.json`, `data` is the machine-local chezmoi `[data]`
+  table from `~/.config/chezmoi/chezmoi.toml`. Secrets (e.g. `bedrock_token`)
+  stay in `[data]` and reach the overlay through the `data` argument, never
+  living in any repo.
+- The overlay is evaluated with `-J $OVERLAY_DIR`, so it may split logic into
+  `*.libsonnet` helper files inside the company repo.
+- Company skills/hooks/agents are still delivered via the plugin marketplace
+  mechanism — the overlay simply adds `enabledPlugins+:` /
+  `extraKnownMarketplaces+:` entries.
 
 ## PostToolUse auto-sync
 
@@ -55,10 +71,16 @@ whenever Claude writes or edits `~/.claude/settings.json` directly. The hook:
 
 1. Computes a semantic diff (sorted-key jq) between the chezmoi-rendered source
    and the live file.
-2. If there is a real change, strips the modify-script-managed env vars
-   (Bedrock, OTEL, CCGATE) and writes the result to
+2. If there is a real change, computes a reverse merge patch —
+   `mergePatch(base, diff(rendered, live))` — and writes the result to
    `$(chezmoi source-path)/.chezmoitemplates/claude-settings-base.json`.
-3. Prints `settings-sync: updated claude-settings-base.json (chezmoi diff pending)`.
+   Overlay-managed values are identical in `rendered` and `live`, so they
+   never enter the patch and never leak into the base — the hook needs no
+   knowledge of any company key names.
+3. Prints `settings-sync: updated claude-settings-base.json (chezmoi diff pending)`,
+   or a `base updated but overlay interaction detected` warning when an edit
+   touched a value the overlay also manages (e.g. a shared array) — exactly
+   the case this skill then reconciles by hand.
 
 **This means drift in settings.json may already be reconciled.** Before
 classifying a settings.json change as ADOPT in step 3 below, check:
@@ -196,7 +218,7 @@ After confirmation, act under `$SRC`:
   should now show no genuine content delta.
 - If you hand-edited a `.tmpl` or `claude-settings-base.json`, run `make lint-tmpl`
   (or `scripts/check-json-tmpl.sh`) from `$SRC` to prove the template still
-  renders to valid JSON on *both* branches (default and bedrock) — a stray comma
+  renders to valid JSON on *both* profiles (default and overlay) — a stray comma
   is easy to introduce and `chezmoi diff` alone will not catch it.
 - Run `make lint` (which now runs `lint-json` + `lint-tmpl`) from `$SRC` so the
   change passes the same checks CI will run.
@@ -217,4 +239,5 @@ PR is merged and `chezmoi apply` is run — which is the normal, reviewed path.
   of inventing work.
 - Keep commits granular (per skill / per concern) so any single change is easy to
   revert later via the source's git history.
-- `dot_claude/ccgate.jsonnet` is no longer chezmoi-managed. Do not re-add it.
+- `ccgate.jsonnet` is company-scope (it belongs in the company overlay repo)
+  and is never chezmoi-managed. Do not re-add it.

--- a/.github/workflows/chezmoi-check.yml
+++ b/.github/workflows/chezmoi-check.yml
@@ -32,6 +32,16 @@ jobs:
           sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply --exclude=scripts -S .
           echo "$PWD/bin" >> "$GITHUB_PATH"
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Install jsonnet (required by the json-tmpl-validate hook)
+        run: |
+          go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
       - name: Run pre-commit (formatting + lint gate)
         uses: pre-commit/action@v3.0.1
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,9 @@ repos:
         language: system
         files: \.json\.tmpl$
         pass_filenames: false
+      - id: merge-patch-test
+        name: settings merge-patch unit tests
+        entry: scripts/test-merge-patch.sh
+        language: system
+        files: (settings-merge-patch\.jq|executable_settings-sync\.sh|test-merge-patch\.sh)$
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: lint lint-json lint-tmpl nvim-check
+.PHONY: lint lint-json lint-tmpl lint-merge-patch nvim-check
 
-lint: lint-json lint-tmpl
+lint: lint-json lint-tmpl lint-merge-patch
 
 NVIM_SRC := private_dot_config/nvim
 STYLUA := $(shell command -v stylua 2>/dev/null || echo $(HOME)/.local/share/nvim/mason/bin/stylua)
@@ -33,3 +33,6 @@ lint-json:
 
 lint-tmpl:
 	@scripts/check-json-tmpl.sh
+
+lint-merge-patch:
+	@scripts/test-merge-patch.sh

--- a/dot_claude/hooks/executable_settings-sync.sh
+++ b/dot_claude/hooks/executable_settings-sync.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 # PostToolUse hook — syncs ~/.claude/settings.json back to chezmoi source
 # Fires after Write or Edit tool calls. Checks if the target was settings.json,
-# then strips modify-script-managed env vars and updates claude-settings-base.json.
+# then folds the user's edit into claude-settings-base.json via a reverse
+# merge patch — overlay-managed values never reach the base (see below).
 # Always exits 0 so it never blocks Claude.
 
 set -e
@@ -65,23 +66,50 @@ SRC=$(chezmoi source-path 2>/dev/null) || {
 
 BASE_PATH="$SRC/$BASE_TEMPLATE"
 
-# Strip modify-script-managed env vars from live settings and write to base
-jq 'del(
-  .env.ANTHROPIC_BEDROCK_BASE_URL,
-  .env.AWS_BEARER_TOKEN_BEDROCK,
-  .env.CLAUDE_CODE_USE_BEDROCK,
-  .env.CLAUDE_CODE_SKIP_BEDROCK_AUTH,
-  .env.CLAUDE_CODE_ENABLE_TELEMETRY,
-  .env.OTEL_METRICS_EXPORTER,
-  .env.OTEL_LOGS_EXPORTER,
-  .env.OTEL_EXPORTER_OTLP_PROTOCOL,
-  .env.OTEL_EXPORTER_OTLP_ENDPOINT,
-  .env.OTEL_EXPORTER_OTLP_HEADERS,
-  .env.CCGATE_OPENAI_API_KEY
-)' "$SETTINGS" > "$BASE_PATH" || {
-  printf 'settings-sync: failed to write %s\n' "$BASE_PATH"
+# Reverse merge-patch: new_base = mergePatch(base, diff(rendered, live)).
+# `rendered` is the full base+overlay render, so overlay-managed values are
+# identical in rendered and live, never enter the patch, and never leak into
+# the base — without this script knowing any overlay key names. Only genuine
+# user edits (additions, changes, deletions) propagate. Objects recurse;
+# scalars and arrays replace atomically; a null in the patch deletes the key.
+NEW_BASE=$(jq -n \
+  --slurpfile base_a "$BASE_PATH" \
+  --argjson rendered "$RENDERED" \
+  --slurpfile live_a "$SETTINGS" '
+  def diff($a; $b):
+    if ($a | type) == "object" and ($b | type) == "object" then
+      reduce ((($a | keys) + ($b | keys)) | unique[]) as $k ({};
+        if ($a | has($k)) and (($b | has($k)) | not) then . + {($k): null}
+        elif ($a | has($k)) | not                    then . + {($k): $b[$k]}
+        elif $a[$k] == $b[$k]                        then .
+        else . + {($k): diff($a[$k]; $b[$k])} end)
+    else $b end;
+  def apply($t; $p):
+    if ($p | type) == "object" then
+      reduce ($p | keys[]) as $k (if ($t | type) == "object" then $t else {} end;
+        if $p[$k] == null then del(.[$k]) else .[$k] = apply(.[$k]; $p[$k]) end)
+    else $p end;
+  apply($base_a[0]; diff($rendered; $live_a[0]))
+') || {
+  printf 'settings-sync: failed to compute base update, skipping\n'
   exit 0
 }
+
+# Atomic write so a failure never truncates the base template
+if ! printf '%s\n' "$NEW_BASE" > "$BASE_PATH.tmp" || ! mv "$BASE_PATH.tmp" "$BASE_PATH"; then
+  printf 'settings-sync: failed to write %s\n' "$BASE_PATH"
+  rm -f "$BASE_PATH.tmp"
+  exit 0
+fi
+
+# Safety valve: if re-rendering (base + overlay) no longer matches the live
+# file, an overlay-managed value (e.g. a shared array) was involved in the
+# edit and the merge patch could not represent it cleanly.
+RECHECK=$(chezmoi cat "$SETTINGS" 2>/dev/null) || RECHECK=""
+if [ -n "$RECHECK" ] && [ "$(printf '%s' "$RECHECK" | jq -S .)" != "$(jq -S . "$SETTINGS")" ]; then
+  printf 'settings-sync: base updated but overlay interaction detected — run the chezmoi-claude-sync skill to reconcile\n'
+  exit 0
+fi
 
 printf 'settings-sync: updated claude-settings-base.json (chezmoi diff pending)\n'
 exit 0

--- a/dot_claude/hooks/executable_settings-sync.sh
+++ b/dot_claude/hooks/executable_settings-sync.sh
@@ -70,27 +70,19 @@ BASE_PATH="$SRC/$BASE_TEMPLATE"
 # `rendered` is the full base+overlay render, so overlay-managed values are
 # identical in rendered and live, never enter the patch, and never leak into
 # the base — without this script knowing any overlay key names. Only genuine
-# user edits (additions, changes, deletions) propagate. Objects recurse;
-# scalars and arrays replace atomically; a null in the patch deletes the key.
+# user edits (additions, changes, deletions) propagate. The filter lives in
+# settings-merge-patch.jq (unit-tested by scripts/test-merge-patch.sh).
+MERGE_FILTER="$(dirname "$0")/settings-merge-patch.jq"
+if [ ! -f "$MERGE_FILTER" ]; then
+  printf 'settings-sync: %s not found, skipping\n' "$MERGE_FILTER"
+  exit 0
+fi
+
 NEW_BASE=$(jq -n \
   --slurpfile base_a "$BASE_PATH" \
   --argjson rendered "$RENDERED" \
-  --slurpfile live_a "$SETTINGS" '
-  def diff($a; $b):
-    if ($a | type) == "object" and ($b | type) == "object" then
-      reduce ((($a | keys) + ($b | keys)) | unique[]) as $k ({};
-        if ($a | has($k)) and (($b | has($k)) | not) then . + {($k): null}
-        elif ($a | has($k)) | not                    then . + {($k): $b[$k]}
-        elif $a[$k] == $b[$k]                        then .
-        else . + {($k): diff($a[$k]; $b[$k])} end)
-    else $b end;
-  def apply($t; $p):
-    if ($p | type) == "object" then
-      reduce ($p | keys[]) as $k (if ($t | type) == "object" then $t else {} end;
-        if $p[$k] == null then del(.[$k]) else .[$k] = apply(.[$k]; $p[$k]) end)
-    else $p end;
-  apply($base_a[0]; diff($rendered; $live_a[0]))
-') || {
+  --slurpfile live_a "$SETTINGS" \
+  -f "$MERGE_FILTER") || {
   printf 'settings-sync: failed to compute base update, skipping\n'
   exit 0
 }

--- a/dot_claude/hooks/settings-merge-patch.jq
+++ b/dot_claude/hooks/settings-merge-patch.jq
@@ -1,0 +1,21 @@
+# Reverse merge patch used by settings-sync.sh:
+#   apply(base; diff(rendered; live))
+# diff is an RFC 7386-style recursive object diff: objects recurse, scalars
+# and arrays replace atomically, keys removed from $b become null. apply
+# applies such a patch; a null in the patch deletes the key.
+# Expects: $base_a / $live_a (slurped arrays) and $rendered.
+# Tested by scripts/test-merge-patch.sh.
+def diff($a; $b):
+  if ($a | type) == "object" and ($b | type) == "object" then
+    reduce ((($a | keys) + ($b | keys)) | unique[]) as $k ({};
+      if ($a | has($k)) and (($b | has($k)) | not) then . + {($k): null}
+      elif ($a | has($k)) | not                    then . + {($k): $b[$k]}
+      elif $a[$k] == $b[$k]                        then .
+      else . + {($k): diff($a[$k]; $b[$k])} end)
+  else $b end;
+def apply($t; $p):
+  if ($p | type) == "object" then
+    reduce ($p | keys[]) as $k (if ($t | type) == "object" then $t else {} end;
+      if $p[$k] == null then del(.[$k]) else .[$k] = apply(.[$k]; $p[$k]) end)
+  else $p end;
+apply($base_a[0]; diff($rendered; $live_a[0]))

--- a/dot_claude/modify_settings.json.tmpl
+++ b/dot_claude/modify_settings.json.tmpl
@@ -1,39 +1,41 @@
 #!/bin/sh
 # chezmoi modify script — generates ~/.claude/settings.json
-# stdin (current file contents) is intentionally ignored; always rebuild from base.
+# stdin (current file contents) is intentionally ignored; always rebuild from
+# the base template, then merge the private overlay repo if one is present.
+#
+# Overlay contract: $OVERLAY_DIR/overlay.jsonnet must be a jsonnet function
+#   function(base, data) base + { ... }
+# where `base` is the rendered claude-settings-base.json and `data` is the
+# machine-local chezmoi [data] table (secrets stay out of any repo).
+set -eu
 
-RESULT='{{ includeTemplate "claude-settings-base.json" . }}'
+OVERLAY_DIR='{{ get . "claude_overlay_dir" | default (joinPath .chezmoi.homeDir ".config/claude-overlay") }}'
+OVERLAY="$OVERLAY_DIR/overlay.jsonnet"
 
-{{- if hasKey . "bedrock_base_url" }}
-RESULT=$(printf '%s' "$RESULT" | jq \
-  --arg url '{{ .bedrock_base_url }}' \
-  --arg token '{{ .bedrock_token }}' \
-  --arg otel '{{ .otel_endpoint }}' \
-  '.env |= . + {
-    "ANTHROPIC_BEDROCK_BASE_URL": $url,
-    "AWS_BEARER_TOKEN_BEDROCK": $token,
-    "CLAUDE_CODE_USE_BEDROCK": "1",
-    "CLAUDE_CODE_SKIP_BEDROCK_AUTH": "1",
-    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
-    "OTEL_METRICS_EXPORTER": "otlp",
-    "OTEL_LOGS_EXPORTER": "otlp",
-    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
-    "OTEL_EXPORTER_OTLP_ENDPOINT": $otel,
-    "OTEL_EXPORTER_OTLP_HEADERS": ("Authorization=" + $token)
-  } |
-  .hooks.PermissionRequest = [{"matcher": "", "hooks": [{"type": "command", "command": "ccgate claude"}]}]')
-{{- end }}
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
 
-{{- if hasKey . "extra_marketplace_url" }}
-RESULT=$(printf '%s' "$RESULT" | jq \
-  --argjson plugins '{{ .extra_plugins | toJson }}' \
-  --arg name '{{ .extra_marketplace_name }}' \
-  --arg url '{{ .extra_marketplace_url }}' \
-  '.enabledPlugins += ($plugins | map({key: ., value: true}) | from_entries) |
-   .extraKnownMarketplaces[$name] = {
-     "source": {"source": "git", "url": $url},
-     "autoUpdate": true
-   }')
-{{- end }}
+# Quoted heredocs: no shell expansion, so quotes/dollars in the JSON are safe.
+cat >"$TMP/base.json" <<'CHEZMOI_BASE_EOF'
+{{ includeTemplate "claude-settings-base.json" . }}
+CHEZMOI_BASE_EOF
 
-printf '%s\n' "$RESULT"
+if [ ! -f "$OVERLAY" ]; then
+  cat "$TMP/base.json"
+  exit 0
+fi
+
+if ! command -v jsonnet >/dev/null 2>&1; then
+  echo "modify_settings: $OVERLAY exists but jsonnet is not installed" >&2
+  echo "  fix: go install github.com/google/go-jsonnet/cmd/jsonnet@latest" >&2
+  exit 1
+fi
+
+cat >"$TMP/data.json" <<'CHEZMOI_DATA_EOF'
+{{ omit . "chezmoi" | toJson }}
+CHEZMOI_DATA_EOF
+
+jsonnet -J "$OVERLAY_DIR" \
+  --tla-code-file base="$TMP/base.json" \
+  --tla-code-file data="$TMP/data.json" \
+  "$OVERLAY"

--- a/scripts/check-json-tmpl.sh
+++ b/scripts/check-json-tmpl.sh
@@ -108,7 +108,8 @@ while IFS= read -r tmpl; do
   if render_modify "$default_cfg" "$tmpl" "default"; then
     if [ "$tmpl" = "$settings_tmpl" ]; then
       if diff <(printf '%s' "$RENDER_MODIFY_OUT" | jq -S .) \
-              <(jq -S . .chezmoitemplates/claude-settings-base.json) >/dev/null; then
+              <(chezmoi execute-template --config "$default_cfg" --source . \
+                  <.chezmoitemplates/claude-settings-base.json | jq -S .) >/dev/null; then
         echo "  OK: $tmpl (default output == base)"
       else
         echo "  FAIL: $tmpl (default) — output differs from claude-settings-base.json" >&2

--- a/scripts/check-json-tmpl.sh
+++ b/scripts/check-json-tmpl.sh
@@ -7,10 +7,14 @@
 # This script renders each template with deterministic, machine-independent
 # data and parses the result with python's json module.
 #
-# modify_*.json.tmpl files are chezmoi modify scripts — they
-# render to shell scripts that are executed to produce JSON. These are
-# validated separately with render_modify() using three data profiles:
-# default (no extras), bedrock-only, and work (extra marketplace + plugins).
+# modify_*.json.tmpl files are chezmoi modify scripts — they render to shell
+# scripts that are executed to produce JSON. These are validated separately
+# with render_modify() under two data profiles:
+#   default — no overlay present: output must equal the base JSON verbatim
+#   overlay — a fixture overlay.jsonnet is present: output must contain the
+#             jsonnet-merged result, including a shell-hostile secret passed
+#             through the heredoc path (requires jsonnet; SKIPped when not
+#             installed locally, FAILs in CI)
 set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
@@ -23,24 +27,28 @@ trap 'rm -rf "$tmpdir"' EXIT
 empty_cfg="$tmpdir/empty.toml"
 printf '[data]\n' >"$empty_cfg"
 
-# Mock bedrock data -> exercises the hasKey bedrock_base_url branch.
-bedrock_cfg="$tmpdir/bedrock.toml"
-cat >"$bedrock_cfg" <<'EOF'
+# Modify-script profiles. claude_overlay_dir must be pinned in every profile
+# so a real ~/.config/claude-overlay on the developer's machine can never
+# leak into the check.
+mkdir -p "$tmpdir/no-overlay" "$tmpdir/overlay"
+cp scripts/fixtures/test-overlay.jsonnet "$tmpdir/overlay/overlay.jsonnet"
+
+default_cfg="$tmpdir/default.toml"
+cat >"$default_cfg" <<EOF
 [data]
-bedrock_base_url = "https://example.invalid/bedrock"
-bedrock_token = "test-token"
-otel_endpoint = "https://example.invalid/otel"
+claude_overlay_dir = "$tmpdir/no-overlay"
 EOF
 
-# Mock work data -> exercises the extra_marketplace_url and ccgate_openai_api_key branches.
-work_cfg="$tmpdir/work.toml"
-cat >"$work_cfg" <<'EOF'
+# test_secret deliberately contains shell-hostile characters to prove the
+# heredoc escaping in the modify script end-to-end.
+overlay_cfg="$tmpdir/overlay.toml"
+cat >"$overlay_cfg" <<EOF
 [data]
-extra_plugins = ["plugin-a@test-marketplace", "plugin-b@test-marketplace"]
-extra_marketplace_name = "test-marketplace"
-extra_marketplace_url = "https://example.invalid/marketplace.git"
-ccgate_openai_api_key = "test-ccgate-key"
+claude_overlay_dir = "$tmpdir/overlay"
+test_secret = "s3cr3t'with\"quotes and \$vars"
 EOF
+# shellcheck disable=SC2016  # the literal $vars is the point of the test
+expected_secret='s3cr3t'\''with"quotes and $vars'
 
 # render <config> <template> <label>
 render() {
@@ -60,9 +68,12 @@ render() {
 
 # render_modify <config> <template> <label>
 # For modify scripts: render the template to a shell script, execute it,
-# then validate the output is valid JSON.
+# then validate the output is valid JSON. On success the produced JSON is
+# left in RENDER_MODIFY_OUT for profile-specific assertions.
+RENDER_MODIFY_OUT=""
 render_modify() {
   local cfg="$1" tmpl="$2" label="$3" out script_out
+  RENDER_MODIFY_OUT=""
   if ! out="$(chezmoi execute-template --config "$cfg" --source . <"$tmpl" 2>&1)"; then
     echo "  FAIL: $tmpl ($label) — template did not render:" >&2
     printf '%s\n' "$out" >&2
@@ -78,6 +89,7 @@ render_modify() {
     printf '%s\n' "$script_out" >&2
     return 1
   fi
+  RENDER_MODIFY_OUT="$script_out"
   echo "  OK: $tmpl ($label)"
 }
 
@@ -90,10 +102,46 @@ while IFS= read -r tmpl; do
 done < <(find . -name '*.json.tmpl' -not -name 'modify_*' -not -path './.git/*' -not -path './.claude/worktrees/*' | sort)
 
 # Validate modify scripts (rendered output is a shell script; execute it, then validate JSON)
+settings_tmpl="./dot_claude/modify_settings.json.tmpl"
 while IFS= read -r tmpl; do
-  render_modify "$empty_cfg"   "$tmpl" "default" || fail=1
-  render_modify "$bedrock_cfg" "$tmpl" "bedrock"  || fail=1
-  render_modify "$work_cfg"    "$tmpl" "work"     || fail=1
+  # default profile: no overlay -> the base must pass through untouched
+  if render_modify "$default_cfg" "$tmpl" "default"; then
+    if [ "$tmpl" = "$settings_tmpl" ]; then
+      if diff <(printf '%s' "$RENDER_MODIFY_OUT" | jq -S .) \
+              <(jq -S . .chezmoitemplates/claude-settings-base.json) >/dev/null; then
+        echo "  OK: $tmpl (default output == base)"
+      else
+        echo "  FAIL: $tmpl (default) — output differs from claude-settings-base.json" >&2
+        fail=1
+      fi
+    fi
+  else
+    fail=1
+  fi
+
+  # overlay profile: fixture overlay present -> jsonnet merge must apply
+  if ! command -v jsonnet >/dev/null 2>&1; then
+    if [ "${CI:-}" = "true" ]; then
+      echo "  FAIL: $tmpl (overlay) — jsonnet is not installed in CI" >&2
+      fail=1
+    else
+      echo "  SKIP: $tmpl (overlay) — jsonnet not installed"
+    fi
+    continue
+  fi
+  if render_modify "$overlay_cfg" "$tmpl" "overlay"; then
+    if [ "$tmpl" = "$settings_tmpl" ]; then
+      got_secret="$(printf '%s' "$RENDER_MODIFY_OUT" | jq -r '.env.TEST_OVERLAY')"
+      if [ "$got_secret" = "$expected_secret" ]; then
+        echo "  OK: $tmpl (overlay merge + escaping)"
+      else
+        echo "  FAIL: $tmpl (overlay) — env.TEST_OVERLAY mismatch: got '$got_secret'" >&2
+        fail=1
+      fi
+    fi
+  else
+    fail=1
+  fi
 done < <(find . -name 'modify_*.json.tmpl' -not -path './.git/*' -not -path './.claude/worktrees/*' | sort)
 
 if [ "$fail" -eq 0 ]; then

--- a/scripts/fixtures/test-overlay.jsonnet
+++ b/scripts/fixtures/test-overlay.jsonnet
@@ -1,0 +1,17 @@
+// Test fixture for scripts/check-json-tmpl.sh — mirrors the shape of a real
+// company overlay (the function(base, data) contract) without real values.
+function(base, data) base + {
+  env+: { TEST_OVERLAY: data.test_secret },
+  hooks+: {
+    PermissionRequest: [
+      { matcher: '', hooks: [{ type: 'command', command: 'true' }] },
+    ],
+  },
+  enabledPlugins+: { 'test-plugin@test-marketplace': true },
+  extraKnownMarketplaces+: {
+    'test-marketplace': {
+      source: { source: 'git', url: 'https://example.invalid/marketplace.git' },
+      autoUpdate: true,
+    },
+  },
+}

--- a/scripts/test-merge-patch.sh
+++ b/scripts/test-merge-patch.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Unit tests for dot_claude/hooks/settings-merge-patch.jq — the reverse merge
+# patch settings-sync.sh uses to fold live settings.json edits back into
+# claude-settings-base.json without leaking overlay-managed values.
+# Each case asserts: apply(base; diff(rendered; live)) == expected.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+FILTER=dot_claude/hooks/settings-merge-patch.jq
+fail=0
+
+# check <label> <base> <rendered> <live> <expected>
+check() {
+  local label="$1" base="$2" rendered="$3" live="$4" expected="$5" got want
+  got="$(jq -cnS \
+    --argjson base_a "[$base]" \
+    --argjson rendered "$rendered" \
+    --argjson live_a "[$live]" \
+    -f "$FILTER")"
+  want="$(printf '%s' "$expected" | jq -cS .)"
+  if [ "$got" = "$want" ]; then
+    echo "  OK: $label"
+  else
+    echo "  FAIL: $label" >&2
+    echo "    expected: $want" >&2
+    echo "    got:      $got" >&2
+    fail=1
+  fi
+}
+
+echo "Testing settings merge-patch filter..."
+
+# User changes a scalar, adds an env key, and deletes a base key while the
+# overlay contributes env.BEDROCK and hooks — none of which may enter the base.
+check "overlay values stay out of base" \
+  '{"model":"opus","env":{"AUTO":"1"},"effortLevel":"high"}' \
+  '{"model":"opus","env":{"AUTO":"1","BEDROCK":"tok"},"effortLevel":"high","hooks":{"PermissionRequest":[{"cmd":"ccgate"}]}}' \
+  '{"model":"sonnet","env":{"AUTO":"1","BEDROCK":"tok","NEW":"y"},"hooks":{"PermissionRequest":[{"cmd":"ccgate"}]}}' \
+  '{"model":"sonnet","env":{"AUTO":"1","NEW":"y"}}'
+
+# No overlay (rendered == base): the live file becomes the new base verbatim.
+check "personal machine passthrough" \
+  '{"a":1,"b":{"c":2}}' \
+  '{"a":1,"b":{"c":2}}' \
+  '{"a":1,"b":{"c":3},"d":4}' \
+  '{"a":1,"b":{"c":3},"d":4}'
+
+# Nested edit only touches the edited leaf, siblings survive.
+check "nested edit keeps siblings" \
+  '{"permissions":{"allow":["Read"],"deny":["sudo"]}}' \
+  '{"permissions":{"allow":["Read"],"deny":["sudo"]}}' \
+  '{"permissions":{"allow":["Read","Write"],"deny":["sudo"]}}' \
+  '{"permissions":{"allow":["Read","Write"],"deny":["sudo"]}}'
+
+# Arrays replace atomically (no element-wise merge).
+check "array replaced atomically" \
+  '{"list":[1,2,3]}' \
+  '{"list":[1,2,3]}' \
+  '{"list":[9]}' \
+  '{"list":[9]}'
+
+# Type change object -> scalar replaces the whole subtree.
+check "type change object to scalar" \
+  '{"x":{"y":1}}' \
+  '{"x":{"y":1}}' \
+  '{"x":"flat"}' \
+  '{"x":"flat"}'
+
+# Deleting an overlay-added key must not disturb the base.
+check "delete of overlay key is a no-op on base" \
+  '{"env":{"AUTO":"1"}}' \
+  '{"env":{"AUTO":"1","BEDROCK":"tok"}}' \
+  '{"env":{"AUTO":"1"}}' \
+  '{"env":{"AUTO":"1"}}'
+
+if [ "$fail" -eq 0 ]; then
+  echo "All merge-patch tests passed."
+else
+  echo "Merge-patch tests failed." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

`~/.claude/settings.json` の生成を「個人base(公開)+ 会社overlay(非公開repo)」の2層モデルに再構成する。

- **Before**: 会社固有の設定(Bedrock env / ccgate hook / 社内marketplace・plugins)が公開repoのmodifyスクリプトにjq分岐としてハードコードされ、値はmachine-localの `chezmoi.toml [data]` にgit管理外で散在
- **After**: 公開repoには汎用マージロジックのみ。会社設定は `~/.config/claude-overlay/`(`claude_overlay_dir` で上書き可)にcloneした非公開repoの `overlay.jsonnet` で管理し、apply時に jsonnet でマージ。overlay が無いマシンは base 素通し

## Changes

- `dot_claude/modify_settings.json.tmpl`: jq分岐を全削除し、`function(base, data)` TLA契約のjsonnetマージに置換。base/dataはquoted heredocで受け渡し(旧 `RESULT='...'` のシングルクォート潜在バグも解消)。overlay有り+jsonnet無しは明示的に失敗
- `dot_claude/hooks/executable_settings-sync.sh`: ハードコードの `del(.env.…)` リストを廃止し、`mergePatch(base, diff(rendered, live))` の逆マージパッチに置換。overlay管理値はキー名を知らずにbaseから排除され、アトミック書き込み+overlay干渉時の警告つき
- `scripts/check-json-tmpl.sh`: bedrock/workプロファイルを default(base素通しアサート)/ overlay(fixture + シェル敵対文字のsecretでマージ・エスケープをend-to-end検証)に刷新。jsonnet未導入時はSKIP、CIではFAIL
- `.chezmoiscripts/*`: go-jsonnet を3つのインストールスクリプトに追加
- `.github/workflows/chezmoi-check.yml`: lintジョブに setup-go + jsonnet インストールを追加
- `.claude/skills/chezmoi-claude-sync/SKILL.md`: overlayモデル・contract・新hook挙動にドキュメント更新

## Verification

- `make lint` パス(default素通し・overlayマージ+エスケープのアサート含む)
- overlay有り+jsonnet無しで非ゼロ終了することを確認(サイレントにBedrock envを剥がさない)
- main と本ブランチで `chezmoi cat` のレンダリング結果が同一(このマシン=overlay無しでは動作不変)
- sync hookのjqパッチをシナリオテスト: 会社マシン相当(ユーザー編集のみbaseへ、overlay値は漏れない)/個人マシン相当(live全体がbaseへ)

## Migration(マージ後・会社マシン側)

1. 会社repoを作成し `overlay.jsonnet`(現行jq分岐と等価)をコミット、`~/.config/claude-overlay` にclone
2. `go install github.com/google/go-jsonnet/cmd/jsonnet@latest`
3. `settings.json` をバックアップ → `chezmoi update` → 適用前後で `jq -S` diff が空を確認
4. `chezmoi.toml [data]` から `bedrock_base_url` / `otel_endpoint` / `extra_plugins` / `extra_marketplace_name` / `extra_marketplace_url` を削除(`bedrock_token` は残す)