### PR TITLE
feat(claude): add prompts list and metrics to worklog hook

### DIFF
--- a/dot_claude/hooks/executable_permission-notify.sh
+++ b/dot_claude/hooks/executable_permission-notify.sh
@@ -1,14 +1,25 @@
 #!/usr/bin/env bash
-set -euo pipefail
+# Notification hook (matcher: permission_prompt): desktop-notify and count.
+#
+# Besides the notification, each invocation appends one line to a per-session
+# counter file under ${XDG_CACHE_HOME:-$HOME/.cache}/claude/perm-prompts/;
+# worklog.sh reads the line count at SessionEnd and deletes the file.
+# Counting must never break the notification, so every step is guarded.
+set -uo pipefail
+
+payload="$(cat)"
 
 title="Claude Code"
 message="Permission required"
+session_id=""
 
-# Parse JSON from stdin if jq is available
 if command -v jq >/dev/null 2>&1; then
-  payload="$(cat)"
-  title="$(printf '%s' "$payload" | jq -r '.title // "Claude Code"')"
-  message="$(printf '%s' "$payload" | jq -r '.message // "Permission required"')"
+  title="$(printf '%s' "$payload" | jq -r '.title // "Claude Code"' 2>/dev/null)" || title="Claude Code"
+  message="$(printf '%s' "$payload" | jq -r '.message // "Permission required"' 2>/dev/null)" || message="Permission required"
+  session_id="$(printf '%s' "$payload" | jq -r '.session_id // ""' 2>/dev/null)" || session_id=""
+elif command -v python3 >/dev/null 2>&1; then
+  session_id="$(printf '%s' "$payload" \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin).get("session_id",""))' 2>/dev/null)" || session_id=""
 fi
 
 case "$(uname -s)" in
@@ -23,3 +34,13 @@ case "$(uname -s)" in
     printf '\a' >/dev/tty 2>/dev/null || true
     ;;
 esac
+
+# Per-session prompt counter: append = atomic-enough increment, count = lines.
+# Kept after the notification so counter/GC I/O never delays the alert.
+# The regex doubles as a path-injection guard since session_id lands in a path.
+count_dir="${XDG_CACHE_HOME:-$HOME/.cache}/claude/perm-prompts"
+if [[ "$session_id" =~ ^[A-Za-z0-9-]+$ ]] && mkdir -p "$count_dir" 2>/dev/null; then
+  printf '.\n' >>"$count_dir/$session_id.count" 2>/dev/null || true
+  # GC counters no SessionEnd consumed (e.g. hosts without CLAUDE_WORKLOG_DIR).
+  find "$count_dir" -type f -mtime +7 -delete 2>/dev/null || true
+fi

--- a/dot_claude/hooks/executable_worklog.sh
+++ b/dot_claude/hooks/executable_worklog.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 # SessionEnd hook: append a per-session work-log entry to a daily Obsidian note.
 #
-# Output goes to $CLAUDE_WORKLOG_DIR/YYYY-MM-DD.md, one section per session.
+# Output goes to $CLAUDE_WORKLOG_DIR/YYYY-MM-DD.md, one section per session:
+# the first user request (依頼), the follow-up prompts (問いかけ), the last
+# assistant message (結果), git context, and session metrics (prompt count,
+# AskUserQuestion count, tool errors, permission prompts, token usage).
+#
+# The permission-prompt count comes from a per-session counter file written by
+# permission-notify.sh under ${XDG_CACHE_HOME:-$HOME/.cache}/claude/perm-prompts/
+# (one line per prompt); this hook consumes and deletes it.
+#
 # The hook is intentionally machine-agnostic: if CLAUDE_WORKLOG_DIR is unset
 # (e.g. a host without the vault) it no-ops, and it NEVER fails the session
 # (always exits 0) so a logging glitch can't disrupt Claude Code.
@@ -14,7 +22,9 @@ input="$(cat)"
 [ -n "${CLAUDE_WORKLOG_DIR:-}" ] || exit 0
 
 # Parse the payload and best-effort summary in a single Python pass.
-# Output: line 1 = "cwd<TAB>reason<TAB>session_id<TAB>started",
+# Output: line 1 = TAB-joined "cwd reason session_id started n_prompts
+#         ask_count err_count tok_out tok_in tok_cache_r tok_cache_w n_calls"
+#         (metric fields are empty when the transcript couldn't be parsed),
 #         then a "---8<---" delimiter, then the multi-line summary.
 parsed="$(CLAUDE_HOOK_PAYLOAD="$input" python3 - <<'PY' 2>/dev/null || true
 import os, json
@@ -42,8 +52,14 @@ def text_of(content):
     return ""
 
 started = ""
-first_user = ""
+prompts = []
 last_asst = ""
+ask_count = 0
+err_count = 0
+seen_calls = set()  # one API call spans several entries repeating the same usage
+usage = {"input_tokens": 0, "output_tokens": 0,
+         "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}
+parsed_any = False
 try:
     with open(transcript, encoding="utf-8") as f:
         for line in f:
@@ -54,19 +70,45 @@ try:
                 e = json.loads(line)
             except Exception:
                 continue
+            if e.get("isSidechain"):
+                continue
             if not started and e.get("timestamp"):
                 started = e["timestamp"]
+            etype = e.get("type")
+            if etype not in ("user", "assistant"):
+                continue
+            parsed_any = True
             msg = e.get("message") or {}
-            role = msg.get("role") or e.get("type")
-            if role == "user" and not first_user:
-                t = text_of(msg.get("content")).strip()
-                # skip tool results / system-injected meta turns
-                if t and not t.startswith("<"):
-                    first_user = t
-            if role == "assistant":
-                t = text_of(msg.get("content")).strip()
+            content = msg.get("content")
+            if etype == "user":
+                if not e.get("isMeta"):
+                    t = text_of(content).strip()
+                    # skip tool results / system-injected turns / interrupts
+                    if t and not t.startswith("<") and not t.startswith("["):
+                        prompts.append(t)
+                if isinstance(content, list):
+                    for b in content:
+                        if isinstance(b, dict) and b.get("type") == "tool_result" \
+                                and b.get("is_error"):
+                            err_count += 1
+            else:
+                t = text_of(content).strip()
                 if t:
                     last_asst = t
+                if isinstance(content, list):
+                    for b in content:
+                        if isinstance(b, dict) and b.get("type") == "tool_use" \
+                                and b.get("name") == "AskUserQuestion":
+                            ask_count += 1
+                u = msg.get("usage")
+                if isinstance(u, dict):
+                    key = msg.get("id") or e.get("requestId") or e.get("uuid")
+                    if key and key not in seen_calls:
+                        seen_calls.add(key)
+                        for k in usage:
+                            v = u.get(k)
+                            if isinstance(v, (int, float)):
+                                usage[k] += int(v)
 except Exception:
     pass
 
@@ -74,13 +116,38 @@ def clip(s, n):
     s = " ".join(s.split())
     return s[:n] + ("…" if len(s) > n else "")
 
+def human(n):
+    if n >= 1_000_000:
+        return "%.1fM" % (n / 1_000_000)
+    if n >= 1_000:
+        return "%.1fk" % (n / 1_000)
+    return str(n)
+
 summary = ""
-if first_user:
-    summary += "**依頼**: " + clip(first_user, 400)
+if prompts:
+    summary += "**依頼**: " + clip(prompts[0], 400)
+if len(prompts) >= 2:
+    shown = prompts[1:16]
+    lines = ["**問いかけ** (%d):" % len(prompts)]
+    for i, p in enumerate(shown, start=2):
+        lines.append("%d. %s" % (i, clip(p, 200)))
+    rest = len(prompts) - 1 - len(shown)
+    if rest > 0:
+        lines.append("…ほか%d件" % rest)
+    summary += "\n\n" + "\n".join(lines)
 if last_asst:
     summary += ("\n\n" if summary else "") + "**結果**: " + clip(last_asst, 600)
 
-print("\t".join([cwd, reason, session_id, started]))
+fields = [cwd, reason, session_id, started]
+if parsed_any:
+    fields += [str(len(prompts)), str(ask_count), str(err_count),
+               human(usage["output_tokens"]), human(usage["input_tokens"]),
+               human(usage["cache_read_input_tokens"]),
+               human(usage["cache_creation_input_tokens"]),
+               str(len(seen_calls))]
+else:
+    fields += [""] * 8
+print("\t".join(fields))
 print("---8<---")
 print(summary)
 PY
@@ -90,8 +157,21 @@ PY
 meta="$(printf '%s\n' "$parsed" | head -n1)"
 summary="$(printf '%s\n' "$parsed" | awk 'f{print} /^---8<---$/{f=1}')"
 
-IFS=$'\t' read -r cwd reason session_id started <<<"$meta"
+IFS=$'\t' read -r cwd reason session_id started n_prompts ask_count err_count \
+  tok_out tok_in tok_cache_r tok_cache_w n_calls <<<"$meta"
 [ -n "${cwd:-}" ] || cwd="$PWD"
+
+# Consume the permission-prompt counter written by permission-notify.sh.
+perm=""
+count_dir="${XDG_CACHE_HOME:-$HOME/.cache}/claude/perm-prompts"
+if [[ "${session_id:-}" =~ ^[A-Za-z0-9-]+$ ]]; then
+  count_file="$count_dir/$session_id.count"
+  # mv first so a prompt racing with SessionEnd can't append between read and rm
+  if mv "$count_file" "$count_file.$$" 2>/dev/null; then
+    perm="$(wc -l <"$count_file.$$" 2>/dev/null | tr -d '[:space:]')" || perm=""
+    rm -f "$count_file.$$" 2>/dev/null || true
+  fi
+fi
 
 # Git context (best effort; skipped cleanly for non-git directories).
 repo=""
@@ -118,6 +198,14 @@ out="$CLAUDE_WORKLOG_DIR/$(date +%Y-%m-%d).md"
   if [ -n "$commits" ]; then
     printf -- '- Commits:\n'
     printf '%s\n' "$commits" | while IFS= read -r c; do printf '    - %s\n' "$c"; done
+  fi
+  if [ -n "${n_prompts:-}" ]; then
+    printf -- '- Metrics: 問いかけ %s · AskUserQuestion %s · ツールエラー %s · 許可プロンプト %s\n' \
+      "$n_prompts" "$ask_count" "$err_count" "${perm:-0}"
+  fi
+  if [ -n "${n_calls:-}" ] && [ "${n_calls:-0}" != "0" ]; then
+    printf -- '- Tokens: out %s · in %s · cache r %s / w %s (累計, %s calls)\n' \
+      "$tok_out" "$tok_in" "$tok_cache_r" "$tok_cache_w" "$n_calls"
   fi
   # shellcheck disable=SC2016  # backticks are literal markdown, not a subshell
   printf -- '- Session: %s · `%s`\n' "${reason:-unknown}" "${session_id:0:8}"


### PR DESCRIPTION
## Summary

Claude Codeの利用を学習ループとして回すため、SessionEndでObsidianに残すworklogを拡張する。
従来は「依頼(最初の発言)/結果(最後の応答)」のみで、試行錯誤の過程や定量情報が残らなかった。

- **worklog.sh**: 全実プロンプトを収集して「問いかけ」一覧を出力(tool_result・meta/システム注入ターン・sidechain・`[Request interrupted...]` を除外。割り込みマーカーが依頼になり得た既存バグも修正)。AskUserQuestion回数・ツールエラー回数を集計し、token usageは `message.id` でdedupして合計(1回のAPI応答がcontent block毎に複数エントリに分割され同一usageを繰り返すため、素朴な合計は約2.5倍過大になる — 実測42エントリ→17ユニーク)
- **permission-notify.sh**: permissionプロンプト毎に `$XDG_CACHE_HOME/claude/perm-prompts/<session_id>.count` へ1行追記。SessionEndでworklog.shが読取り・削除。未消費ファイルは7日でGC。通知を計数より先に実行し遅延を回避

### 出力例

```markdown
- Metrics: 問いかけ 2 · AskUserQuestion 2 · ツールエラー 3 · 許可プロンプト 2
- Tokens: out 26.0k · in 9.7k · cache r 846.4k / w 95.0k (累計, 17 calls)
```

両フックともフェイルセーフ維持(解析失敗時は該当行を省略するだけで、通知・セッションは絶対に壊さない)。

## Test plan

- [x] `make lint` / `pre-commit run shellcheck` パス
- [x] notify単体: カウンタが呼び出し回数分の行数になる(jqなしPATHでもpython3 fallbackで動作、exit 0)
- [x] worklog単体: 実transcript(`541de1b0`)で期待値一致(問いかけ2・Ask 2・エラー3・perm消費・out 26.0k/17 calls)、カウンタ削除確認
- [x] 失敗ドリル: transcript欠損/`CLAUDE_WORKLOG_DIR`未設定 → exit 0、Metrics/Tokens行省略
- [x] code-reviewerセルフレビュー済み(Warning 3件: カウンタ読取TOCTOU→mvでアトミック化、通知を計数より先へ、sidechainのtimestamp混入修正)