### PR TITLE
feat(claude): add claude-inbox for waiting-session recovery

### DIFF
--- a/.chezmoitemplates/claude-settings-base.json
+++ b/.chezmoitemplates/claude-settings-base.json
@@ -157,6 +157,15 @@
             "command": "~/.claude/hooks/permission-notify.sh"
           }
         ]
+      },
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/claude-inbox-hook.sh"
+          }
+        ]
       }
     ],
     "Stop": [
@@ -168,6 +177,15 @@
             "command": "~/.claude/hooks/stop-review.sh"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/claude-inbox-hook.sh"
+          }
+        ]
       }
     ],
     "SessionEnd": [
@@ -177,6 +195,26 @@
           {
             "type": "command",
             "command": "~/.claude/hooks/worklog.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/claude-inbox-hook.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/claude-inbox-hook.sh"
           }
         ]
       }

--- a/dot_claude/hooks/executable_claude-inbox-hook.sh
+++ b/dot_claude/hooks/executable_claude-inbox-hook.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Claude session inbox: track which sessions are waiting for the user.
+#
+# Registered for four events (dispatch on hook_event_name from stdin):
+#   Stop              -> write state "waiting"
+#   Notification      -> write state "permission" (matcher: permission_prompt;
+#                        may linger after approval until the next Stop
+#                        overwrites it — acceptable, self-corrects)
+#   UserPromptSubmit  -> the user is back at this session: clear its entry
+#   SessionEnd        -> clear its entry
+#
+# State: one JSON per session under $CLAUDE_INBOX_DIR (default
+# ~/.cache/claude-inbox), consumed by ~/.local/bin/claude-inbox.
+# Sessions outside tmux are skipped: the inbox's whole point is jumping to
+# the pane, and unjumpable entries would only pollute the list.
+# Like worklog.sh, this hook NEVER fails the session (always exits 0).
+set -uo pipefail
+
+input="$(cat)"
+
+[ -n "${TMUX_PANE:-}" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+dir="${CLAUDE_INBOX_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/claude-inbox}"
+
+event="$(jq -r '.hook_event_name // empty' <<<"$input" 2>/dev/null)"
+[ -n "$event" ] || event="${1:-}"
+sid="$(jq -r '.session_id // empty' <<<"$input" 2>/dev/null)"
+# The regex doubles as a path-injection guard since session_id lands in a
+# path (same convention as worklog.sh / permission-notify.sh).
+[[ "$sid" =~ ^[A-Za-z0-9-]+$ ]] || exit 0
+f="$dir/$sid.json"
+
+case "$event" in
+  UserPromptSubmit | SessionEnd)
+    rm -f "$f" 2>/dev/null
+    exit 0
+    ;;
+  Stop) state="waiting" ;;
+  Notification) state="permission" ;;
+  *) exit 0 ;;
+esac
+
+# A Stop re-fired by another Stop hook's block (stop-review.sh) is not a
+# fresh "waiting for input" moment; skip to avoid double writes.
+[ "$(jq -r '.stop_hook_active // false' <<<"$input" 2>/dev/null)" = "true" ] && exit 0
+
+# Pane ID (%N) is the jump target: unique for the tmux server lifetime,
+# unlike window indices (renumber-windows on). #S:#I.#P is display-only.
+target="$(tmux display-message -p -t "$TMUX_PANE" '#S:#I.#P' 2>/dev/null)" || exit 0
+
+cwd="$(jq -r '.cwd // empty' <<<"$input" 2>/dev/null)"
+[ -n "$cwd" ] || cwd="$PWD"
+transcript="$(jq -r '.transcript_path // empty' <<<"$input" 2>/dev/null)"
+
+# Git context (best effort, same as worklog.sh).
+repo=""
+branch=""
+if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  top="$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null)"
+  [ -n "$top" ] && repo="$(basename "$top")"
+  branch="$(git -C "$cwd" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+fi
+
+# One-line summary: last assistant text from the transcript tail, clipped.
+# Rich detail is rendered lazily by `claude-inbox preview`.
+summary=""
+if [ -n "$transcript" ] && [ -r "$transcript" ]; then
+  summary="$(tail -n 40 "$transcript" 2>/dev/null | jq -nrR '
+    [ inputs | fromjson? // empty
+      | select(.message.role? == "assistant")
+      | .message.content
+      | if type == "array"
+        then (map(select(.type? == "text") | .text) | join(" "))
+        else tostring end
+      | select(length > 0)
+    ] | last // ""' 2>/dev/null | tr -s ' \t\n' '   ' | sed 's/[[:space:]]*$//' | cut -c 1-160)" || summary=""
+fi
+
+mkdir -p "$dir" 2>/dev/null || exit 0
+tmp="$f.tmp.$$"
+# tmp+mv keeps writes atomic: the status bar polls this dir every second.
+jq -n \
+  --arg sid "$sid" --arg state "$state" --arg pane "$TMUX_PANE" \
+  --arg target "$target" --arg cwd "$cwd" --arg repo "$repo" \
+  --arg branch "$branch" --arg transcript "$transcript" --arg summary "$summary" \
+  '{session_id: $sid, state: $state, pane: $pane, target: $target,
+    cwd: $cwd, repo: $repo, branch: $branch, transcript_path: $transcript,
+    summary: $summary, ts: now | floor}' >"$tmp" 2>/dev/null \
+  && mv "$tmp" "$f" 2>/dev/null
+rm -f "$tmp" 2>/dev/null
+
+# Piggyback a prune here: without it, a pane killed outside SessionEnd
+# would inflate the status badge until the user next opens the picker.
+command -v claude-inbox >/dev/null 2>&1 && claude-inbox gc 2>/dev/null
+
+exit 0

--- a/dot_local/bin/executable_claude-inbox
+++ b/dot_local/bin/executable_claude-inbox
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# claude-inbox: list/jump-to Claude Code sessions waiting for input.
+#
+# State files are written by ~/.claude/hooks/claude-inbox-hook.sh (one JSON
+# per session). This CLI reads them:
+#   count   -> number of waiting sessions (called every second from tmux
+#              status-interval, so it must stay glob-only: no jq, no tmux)
+#   status  -> tmux status-right segment; empty string when nothing waits
+#   gc      -> drop entries whose tmux pane died or that are older than 48h
+#   list    -> TSV (pane, label, age, summary) for fzf, newest first
+#   pick    -> fzf picker; jumps the tmux client to the chosen pane
+#   preview -> detail view for fzf --preview (transcript tail)
+set -uo pipefail
+
+dir="${CLAUDE_INBOX_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/claude-inbox}"
+
+count() {
+  set -- "$dir"/*.json
+  if [ -e "${1:-}" ]; then echo "$#"; else echo 0; fi
+}
+
+status() {
+  n="$(count)"
+  # Print nothing when idle so the status segment disappears entirely.
+  [ "$n" -gt 0 ] && printf '#[fg=#f9e2af,bold] ⏳ %s #[default]' "$n"
+  return 0
+}
+
+gc() {
+  [ -d "$dir" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  # Entries older than 48h: the session is gone in every practical sense.
+  find "$dir" -name '*.json' -mmin +2880 -delete 2>/dev/null
+  for f in "$dir"/*.json; do
+    [ -e "$f" ] || break
+    pane="$(jq -r '.pane // empty' "$f" 2>/dev/null)"
+    # has-session, not display-message: the latter exits 0 even for a
+    # nonexistent pane (it silently falls back to the current target).
+    if [ -z "$pane" ] || ! tmux has-session -t "$pane" 2>/dev/null; then
+      rm -f "$f"
+    fi
+  done
+}
+
+list() {
+  gc
+  set -- "$dir"/*.json
+  [ -e "${1:-}" ] || return 0
+  cat "$@" 2>/dev/null | jq -rs '
+    def age: (now - .ts) | floor
+      | if . < 60 then "\(.)s"
+        elif . < 3600 then "\(. / 60 | floor)m"
+        else "\(. / 3600 | floor)h" end;
+    sort_by(-.ts) | .[]
+    | [ .pane,
+        "\(if .state == "permission" then "🔐" else "⏳" end) \(if (.repo // "") != "" then .repo else (.cwd | split("/") | last) end)\(if (.branch // "") != "" then "(\(.branch))" else "" end) \(.target)",
+        age,
+        (.summary // "") ]
+    | @tsv'
+}
+
+pick() {
+  # {1} is safe unquoted: field 1 is always a tmux-generated pane id (%N).
+  sel="$(list | fzf --delimiter '\t' --with-nth 2.. \
+    --preview "$0 preview {1}" --preview-window 'down,60%,wrap' \
+    --prompt 'claude-inbox> ')"
+  [ -n "$sel" ] || return 0
+  pane="${sel%%$'\t'*}"
+  if [ -n "${TMUX:-}" ]; then
+    tmux switch-client -t "$pane" \; select-window -t "$pane" \; select-pane -t "$pane"
+  else
+    tmux attach-session -t "$pane"
+  fi
+  # Keep the state file: UserPromptSubmit clears it when the user answers.
+}
+
+preview() {
+  pane="${1:-}"
+  [ -n "$pane" ] || return 0
+  for f in "$dir"/*.json; do
+    [ -e "$f" ] || break
+    [ "$(jq -r '.pane // empty' "$f" 2>/dev/null)" = "$pane" ] || continue
+    jq -r '"\(if (.repo // "") != "" then .repo else "no-repo" end)\(if (.branch // "") != "" then " (\(.branch))" else "" end)  [\(.state)]\n\(.cwd)\n"' "$f" 2>/dev/null
+    transcript="$(jq -r '.transcript_path // empty' "$f" 2>/dev/null)"
+    if [ -n "$transcript" ] && [ -r "$transcript" ]; then
+      tail -n 80 "$transcript" 2>/dev/null | jq -rR '
+        fromjson? // empty
+        | select(.message.role? == "assistant")
+        | .message.content
+        | if type == "array"
+          then (map(select(.type? == "text") | .text) | join("\n"))
+          else tostring end
+        | select(length > 0)' 2>/dev/null | tail -n 30
+    fi
+    return 0
+  done
+}
+
+case "${1:-}" in
+  count)   count ;;
+  status)  status ;;
+  gc)      gc ;;
+  list)    list ;;
+  pick)    pick ;;
+  preview) preview "${2:-}" ;;
+  *)
+    echo "usage: claude-inbox {count|status|gc|list|pick|preview <pane>}" >&2
+    exit 1
+    ;;
+esac

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -109,3 +109,12 @@ set -g window-style 'bg=default'
 set -g window-active-style 'bg=default'
 set -g pane-border-style 'fg=#6c7086'
 set -g pane-active-border-style 'fg=#89b4fa,bold'
+
+# -----------------------
+# Claude Inbox (after TPM so it appends to Catppuccin's status-right)
+# -----------------------
+# Shows "⏳ N" while Claude sessions wait for input; prefix+a opens a fzf
+# picker that jumps to the waiting pane. Absolute path: tmux #() and popups
+# don't reliably have ~/.local/bin on PATH.
+set -ga status-right "#($HOME/.local/bin/claude-inbox status)"
+bind a display-popup -E -w 80% -h 60% "$HOME/.local/bin/claude-inbox pick"


### PR DESCRIPTION
## Summary

複数のtmux session/windowでClaude Codeを並行運用していると、離席後に「どのセッションが入力待ちか」を忘れ、裏に回したセッションの回収漏れが起きる。既存のbell通知(monitor-bell)は一瞬で消えるため解決になっていなかった。

永続的なローカルinboxを追加する(3本柱ロードマップ 柱2 #94 のローカル軽量版。worklogフック PR #93 のパターンを流用):

- **`dot_claude/hooks/claude-inbox-hook.sh`** — Stop / Notification(permission_prompt) / UserPromptSubmit / SessionEnd の4イベントを1スクリプトで処理。セッションごとの待機状態JSONを `~/.cache/claude-inbox/` に書き込み(tmux pane IDをジャンプ先として保存)、ユーザーが回答 or セッション終了で削除。常に exit 0、tmux外では no-op(worklog.sh と同じ契約)。
- **`dot_local/bin/claude-inbox`** — CLI。`count`/`status` はglobのみのホットパス(tmux status-interval 1 で毎秒実行、~3ms)。`gc` は死んだpane・48h超のエントリを回収。`pick` は fzf popup で待機セッションへ一発ジャンプ。
- **`.chezmoitemplates/claude-settings-base.json`** — 4イベントへのhook登録(既存エントリへの追加のみ)。
- **`dot_tmux.conf`** — status-right に「⏳ N」バッジ(0件なら非表示)、`prefix + a` でピッカー起動。TPM後セクションに追記(既存パターン踏襲)。

## Review

code-reviewer によるセルフレビュー済み。指摘を反映:
- session_id の正規表現ガード(パストラバーサル対策、worklog.sh/permission-notify.sh と同一規約)
- hook書き込み時に gc をピギーバック(SessionEnd を経ずに kill されたpaneのバッジ残留対策)
- `list` の `cat` に 2>/dev/null(gc との競合時のノイズ抑制)、tmpファイル名に `$$` 付与

## Test plan

- [x] shellcheck / `make lint`(JSON + テンプレートレンダリング + merge-patchテスト)
- [x] fake payload テスト: Stop→生成 / UserPromptSubmit→削除 / 不正JSON・TMUX_PANEなし・`../evil` sid でも exit 0
- [x] `claude-inbox count` 3ms(毎秒ポーリング要件 <10ms)
- [x] gc: 死んだpaneのエントリを回収
- [ ] マージ後 `chezmoi apply` して実セッションで payload フィールド(`hook_event_name`/`stop_hook_active`)と `prefix+a` ピッカーをE2E確認

Refs #94