### PR TITLE
feat(memo): point memodir at the Obsidian inbox

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -1,12 +1,12 @@
 {{ $email := or (env "GIT_EMAIL") (promptStringOnce . "email" "What is your email address") -}}
 {{ $name := or (env "GIT_NAME") (promptStringOnce . "name" "What is your Github username") -}}
-{{ $memo_dir := "Documents/memo/_posts" -}}
+{{ $memo_dir := "Documents/ob_edgissa/00_inbox/personal" -}}
 {{ if env "CI" -}}
-{{   $memo_dir = "Documents/memo/_posts" -}}
+{{   $memo_dir = "Documents/ob_edgissa/00_inbox/personal" -}}
 {{ else if hasKey . "memo_dir" -}}
 {{   $memo_dir = .memo_dir -}}
 {{ else -}}
-{{   $memo_dir = promptStringOnce . "memo_dir" "Memo directory path under $HOME" "Documents/memo/_posts" -}}
+{{   $memo_dir = promptStringOnce . "memo_dir" "Memo directory under $HOME (work machine: Documents/ob_edgissa/00_inbox/office)" "Documents/ob_edgissa/00_inbox/personal" -}}
 {{ end -}}
 {{ $op_account := "" -}}
 {{ if env "CI" -}}

--- a/.chezmoiscripts/run_onchange_ensure-memo-dir.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_ensure-memo-dir.sh.tmpl
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+{{ includeTemplate "install-prelude.sh" }}
+
+# Re-runs whenever the memo_dir prompt answer changes.
+# memo_dir: {{ index . "memo_dir" | default "Documents/ob_edgissa/00_inbox/personal" }}
+
+MEMO_DIR="${HOME}/{{ index . "memo_dir" | default "Documents/ob_edgissa/00_inbox/personal" }}"
+PARENT_DIR="$(dirname "${MEMO_DIR}")"
+
+# `memo new` writes with os.Create and never creates its memodir, so a missing
+# directory makes the very first capture fail. Create it here, but only when the
+# parent already exists: on a machine without the Obsidian vault this must stay a
+# no-op rather than leave behind an empty vault skeleton for Obsidian to sync.
+if [ ! -d "${PARENT_DIR}" ]; then
+  log "Parent ${PARENT_DIR} not found. Skipping memo directory creation."
+  exit 0
+fi
+
+if [ ! -d "${MEMO_DIR}" ]; then
+  log "Creating memo directory ${MEMO_DIR}"
+  mkdir -p "${MEMO_DIR}"
+fi

--- a/dot_zshenv.tmpl
+++ b/dot_zshenv.tmpl
@@ -33,7 +33,11 @@ export PATH="$HOME/.local/bin:$PATH"
 # Cargo (Rust)
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
-# Claude Code work-log output dir (consumed by ~/.claude/hooks/worklog.sh).
-# Only set when the Obsidian vault exists; the hook no-ops if this is unset,
-# keeping ~/.claude portable across machines without the vault.
-[ -d "$HOME/Documents/ob_edgissa" ] && export CLAUDE_WORKLOG_DIR="$HOME/Documents/ob_edgissa/claude/worklog"
+# Obsidian vault. Single source of truth for vault-derived paths.
+# Only set when the vault exists, so machines without it degrade cleanly:
+# the worklog hook no-ops and `bmemo` reports a clear error.
+if [ -d "$HOME/Documents/ob_edgissa" ]; then
+  export OBSIDIAN_VAULT="$HOME/Documents/ob_edgissa"
+  # Claude Code work-log output dir (consumed by ~/.claude/hooks/worklog.sh).
+  export CLAUDE_WORKLOG_DIR="$OBSIDIAN_VAULT/claude/worklog"
+fi

--- a/private_dot_config/memo/config.toml.tmpl
+++ b/private_dot_config/memo/config.toml.tmpl
@@ -1,4 +1,4 @@
-memodir = "${HOME}/{{ index . "memo_dir" | default "Documents/memo/_posts" }}"
+memodir = "${HOME}/{{ index . "memo_dir" | default "Documents/ob_edgissa/00_inbox/personal" }}"
 editor = "nvim"
 column = 20
 width = 0

--- a/private_dot_config/memo/template.md
+++ b/private_dot_config/memo/template.md
@@ -1,7 +1,5 @@
 ---
 created: {{.Date}}
-tags:
-  - inbox
 ---
 
 # {{.Title}}

--- a/private_dot_config/zsh/functions.zsh
+++ b/private_dot_config/zsh/functions.zsh
@@ -93,3 +93,10 @@ function ask() {
     claude -p --model haiku -- "$@"
   fi
 }
+
+# Draft a blog post with memo (bare `memo` captures into the Obsidian inbox)
+# MEMODIR is the only setting memo honours from the environment.
+function bmemo() {
+  [ -z "$OBSIDIAN_VAULT" ] && { echo "bmemo: OBSIDIAN_VAULT is not set" >&2; return 1; }
+  MEMODIR="$OBSIDIAN_VAULT/20_tech/blog/_posts" command memo "$@"
+}


### PR DESCRIPTION
## 何を

`memo` (mattn/memo v0.0.22) を Obsidian vault の `00_inbox` へのクイックキャプチャに転用する。
会社機と個人機で保存先を分ける (`00_inbox/office` / `00_inbox/personal`)。

新しいコマンドは追加していない。`memo new` は既に `YYYY-MM-DD-title.md` を作って
nvim で開く (`editor = "nvim"`)。引数なしなら `Title:` を聞かれ、空 Enter で
`YYYY-MM-DD.md` になる。足りなかったのは保存先だけだった。

## なぜ

`memodir` は `20_tech/blog/_posts` を向いており、memo は事実上ブログ下書きツールだった。
inbox に付け替え、ブログ側は `bmemo` ラッパーに逃がす。

会社/個人の切り分けは `chezmoi init` のプロンプト (`memo_dir`) で行う。
`.chezmoi.yaml.tmpl` の `promptStringOnce` と `config.toml.tmpl` の連携は既にあり、
既存の仕組みに乗るだけで済む。

## 調査で確定した memo の仕様 (v0.0.22 ソース実測)

| 事項 | 実測結果 |
|---|---|
| 設定ファイル | `$HOME/.config/memo/config.toml` に固定。`--config` 無し、`XDG_CONFIG_HOME` は読まない |
| 実行時に上書きできる env | **`MEMODIR` のみ** (`main.go:211,241`)。`MEMOTEMPLATE` は存在しない |
| memodir の自動作成 | **しない**。`cmdNew` は `os.Create` を直接呼ぶ |
| stdin が非 TTY のとき | エディタを開かず `copyFromStdin` する |
| `escape()` | `[ <>:"/\|?*%#]` を `-` に潰す。`memo new` は第1引数しかタイトルにしない |

`MEMODIR` が唯一の実行時上書き手段であることが、`bmemo` をラッパーにした理由。
`memotemplate` は上書きできないため `memo` と `bmemo` はテンプレートを共有する。

## 変更点

- `.chezmoi.yaml.tmpl` — `memo_dir` の既定を `Documents/ob_edgissa/00_inbox/personal` に。
  プロンプト文言で会社機は `office` と示す
- `private_dot_config/memo/config.toml.tmpl` — フォールバック既定値を新値に追随
- `private_dot_config/memo/template.md` — `tags: - inbox` を削除。テンプレートは `bmemo`
  とも共有されるためブログ記事に付いてしまう。また obsidian-tidy がノートを `20_tech/` へ
  移した後もタグが残り、嘘になる。ノートの居場所はフォルダが表している
- `dot_zshenv.tmpl` — `OBSIDIAN_VAULT` を導入し `CLAUDE_WORKLOG_DIR` をそこから導出。
  値は従来と同一文字列なので worklog hook は非退行
- `private_dot_config/zsh/functions.zsh` — `bmemo` を追加 (`MEMODIR` 上書きで blog/_posts へ)
- `.chezmoiscripts/run_onchange_ensure-memo-dir.sh.tmpl` — memodir を作成。
  **親ディレクトリが存在するときだけ**動くので、vault の無いマシンでは no-op

## 検証

すべて実行して確認した。

- `chezmoi execute-template` — CI モードで `memo_dir: "Documents/ob_edgissa/00_inbox/personal"`、
  rollout 後の data で `memodir = "${HOME}/Documents/ob_edgissa/00_inbox/personal"`
- **`CLAUDE_WORKLOG_DIR` 非退行** — 新旧 zshenv を render して source。両方とも
  `/Users/edgissa/Documents/ob_edgissa/claude/worklog` で一致
- **`memo new` の end-to-end**（隔離した偽 memodir + PATH 先頭の偽 nvim + PTY）
  - タイトルあり → `2026-07-10-テストメモ.md` が `created:` + `# テストメモ` で生成され、nvim が開く
  - 2回目の実行では上書きされない（shasum 一致）
  - 引数なし + 空 Enter → `2026-07-10.md`
  - `"会議 メモ / 議事録"` → `2026-07-10-会議-メモ-議事録.md`
- **`bmemo`** — 偽 memo で観測し `MEMODIR=$OBSIDIAN_VAULT/20_tech/blog/_posts` が渡ることを確認。
  `OBSIDIAN_VAULT` 未設定なら exit 1 + stderr。素の `memo` に `MEMODIR` は漏れない
- **`run_onchange_ensure-memo-dir`** — vault あり→作成 / 2回目→冪等 / vault なし→no-op
  (`find` で0件を確認) / `CI=1`→prelude が skip、の4パターン
- 既存ブログ下書き32件は無傷
- `make lint` と `pre-commit` はグリーン

## マージ後の移行手順（このマシン）

`promptStringOnce` は答え済みのマシンに再質問しない。実機の `~/.config/chezmoi/chezmoi.yaml`
には既に `memo_dir: "Documents/ob_edgissa/20_tech/blog/_posts"` が入っているため、
**apply するだけでは `memo` は今までどおりブログに書き続ける**（`bmemo` と同じ場所になる）。

1. `~/.config/chezmoi/chezmoi.yaml` の `memo_dir` を `Documents/ob_edgissa/00_inbox/personal` に書き換え
2. `chezmoi diff` で確認してから、対象パスに scope して `chezmoi apply`
   (`run_onchange_ensure-memo-dir` が `00_inbox/personal` を作る)

## 既知の制約: obsidian-tidy はサブディレクトリを見ない

`~/.claude/skills/obsidian-tidy/SKILL.md` は対象を「`00_inbox/` 直下の `*.md`」と明示的に
限定している。よって `00_inbox/personal/` のノートは日次の自動分類に乗らない。
この skill は chezmoi 管理外（live の `~/.claude/skills/` にのみ存在）なので本 PR では触らない。
別途 `00_inbox/*/` も走査するよう拡張が必要。