### PR TITLE
feat(claude): default to claude-fable-5 model

### DIFF
--- a/.chezmoitemplates/claude-settings-base.json
+++ b/.chezmoitemplates/claude-settings-base.json
@@ -136,7 +136,7 @@
     "ask": ["Bash(gh pr merge:*)"],
     "defaultMode": "plan"
   },
-  "model": "opus[1m]",
+  "model": "claude-fable-5[1m]",
   "alwaysThinkingEnabled": true,
   "effortLevel": "high",
   "enableAllProjectMcpServers": true,


### PR DESCRIPTION
## 概要

ライブ `~/.claude/settings.json` のドリフト解消(chezmoi-claude-sync)。
本日 `/model` で保存された `claude-fable-5[1m]` を base テンプレートへ ADOPT する。
これを取り込まずに settings.json を apply するとモデル設定が `opus[1m]` に巻き戻るため。

- セマンティック差分(`chezmoi cat | jq -S` vs live)で確認した実質差分は model のみ
- 会社マシンは jsonnet オーバーレイが model を上書きするため影響なし
- キー順序ドリフトはマージ後の `chezmoi apply` で正規化される

## 検証

- `make lint` 全パス(base+overlay 両プロファイルのレンダリング検証込み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)