### PR TITLE
feat(claude): add frontend-design, slack, playwright plugins to base

### DIFF
--- a/.chezmoitemplates/claude-settings-base.json
+++ b/.chezmoitemplates/claude-settings-base.json
@@ -206,8 +206,11 @@
     "commit-commands@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "document-skills@anthropic-agent-skills": true,
+    "frontend-design@claude-plugins-official": true,
     "gopls-lsp@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
+    "slack@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
## Summary

- `enabledPlugins` に公式プラグイン3件を `claude-settings-base.json` へ追加
  - `frontend-design@claude-plugins-official`
  - `playwright@claude-plugins-official`
  - `slack@claude-plugins-official`
- `hl-architecture-knowledge` / `issuegen`（homelife marketplace）は base に含めない — overlay の `enabledPlugins+:` で管理する想定

## Background

`chezmoi status ~/.claude` が `MM .claude/settings.json` を報告していた。
セマンティック差分（`chezmoi cat | jq -S` vs live `jq -S`）を確認したところ、
上記5プラグインが live に直接追加されていたが PostToolUse hook が自動同期していなかった。

公式プラグインは全マシン共通なのでbaseに採用、homelife専用マーケットプレース依存の2件はoverlayに委ねる。

## Test plan

- [x] `make lint` 通過（JSON syntax + tmpl render + merge-patch tests）
- [x] `diff <(chezmoi cat --source <worktree> ~/.claude/settings.json | jq -S .) <(jq -S . ~/.claude/settings.json)` → homelife 2プラグインのみ残存（意図的 DISCARD）
- [ ] CI (pre-commit hooks) pass