### PR TITLE
fix(chezmoi): add bedrock_token prompt to chezmoi init

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -24,6 +24,14 @@
 {{ else -}}
 {{   $useOnePasswordSSHAgent = promptBoolOnce . "useOnePasswordSSHAgent" "Use 1Password SSH Agent for GitHub?" false -}}
 {{ end -}}
+{{ $bedrock_token := "" -}}
+{{ if env "CI" -}}
+{{   $bedrock_token = "" -}}
+{{ else if hasKey . "bedrock_token" -}}
+{{   $bedrock_token = .bedrock_token -}}
+{{ else -}}
+{{   $bedrock_token = promptStringOnce . "bedrock_token" "Bedrock API token for Claude Code (leave empty to skip)" -}}
+{{ end -}}
 
 data:
   email: {{ $email | quote }}
@@ -31,3 +39,4 @@ data:
   memo_dir: {{ $memo_dir | quote }}
   op_account: {{ $op_account | quote }}
   useOnePasswordSSHAgent: {{ $useOnePasswordSSHAgent }}
+  bedrock_token: {{ $bedrock_token | quote }}


### PR DESCRIPTION
## 何が壊れていたか

`chezmoi apply` が以下のエラーで失敗していた:

```
RUNTIME ERROR: Field does not exist: bedrock_token
    /Users/kazuya.a.isawa/.config/claude-overlay/overlay.jsonnet:5:31-49
```

`dot_claude/modify_settings.json.tmpl` が `overlay.jsonnet` を呼ぶ際に chezmoi の `data` テーブルを渡すが、`.chezmoi.yaml.tmpl` に `bedrock_token` が定義されていなかったため `data.bedrock_token` が存在せず、Jsonnet のランタイムエラーが発生していた。

## 修正内容

`.chezmoi.yaml.tmpl` に `bedrock_token` の `promptStringOnce` ブロックを追加:

- **変数宣言ブロック**: `$useOnePasswordSSHAgent` の後に `$bedrock_token` ブロックを追加
  - CI 環境では空文字列にフォールバック
  - `chezmoi.yaml` に既存のキーがあればその値を使用
  - 未設定の場合は `promptStringOnce` でインタラクティブに入力を促す
- **`data:` セクション**: `bedrock_token: {{ $bedrock_token | quote }}` を末尾に追加

## 適用後の手順

1. **新規セットアップ時**: `chezmoi init` を再実行すると `bedrock_token` のプロンプトが表示される
2. **既存環境の場合**: `~/.config/chezmoi/chezmoi.yaml` に手動で `bedrock_token: "..."` を追記してから `chezmoi apply` を実行する
3. **スキップする場合**: プロンプトで空 Enter を押すと空文字列がセットされ、overlay.jsonnet はトークンなしで動作する

## テスト

```
CI=true make lint  # 全チェック通過
```