### PR TITLE
fix(install): support Amazon Linux (amzn) in build-deps script

### DIFF
--- a/.chezmoiscripts/run_once_before_install-build-deps.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_install-build-deps.sh.tmpl
@@ -20,6 +20,16 @@ if [ -f /etc/os-release ]; then
       sudo dnf groupinstall -y "Development Tools"
       sudo dnf install -y openssl-devel pkg-config cmake zip unzip
       ;;
+    amzn)
+      # Amazon Linux 2023 uses dnf; Amazon Linux 2 uses yum
+      if command -v dnf >/dev/null 2>&1; then
+        sudo dnf groupinstall -y "Development Tools"
+        sudo dnf install -y openssl-devel pkg-config cmake zip unzip
+      else
+        sudo yum groupinstall -y "Development Tools"
+        sudo yum install -y openssl-devel pkg-config cmake zip unzip
+      fi
+      ;;
     arch|manjaro|endeavouros)
       sudo pacman -Syu --noconfirm --needed base-devel openssl pkg-config cmake zip unzip
       ;;


### PR DESCRIPTION
## Summary
- `chezmoi init` on Amazon Linux (`/etc/os-release` `ID=amzn`) failed because the distro `case` in `install-build-deps.sh.tmpl` had no `amzn` branch and fell into the unsupported-distro path, exiting 1.
- Added an `amzn` case that installs the same build deps (Development Tools group + `openssl-devel pkg-config cmake zip unzip`), using `dnf` on Amazon Linux 2023 and falling back to `yum` on Amazon Linux 2.

## Test plan
- [x] `make lint` passes
- [x] `bash -n` syntax check on the extracted linux branch of the template
- [x] Simulated `ID=amzn` case dispatch locally, confirmed it hits the new branch and selects `dnf`/`yum` correctly based on availability
- [ ] Re-run `chezmoi init` on the Amazon Linux host that originally hit this failure