### PR TITLE
docs(install): add 1Password SSH agent runbook

### DIFF
--- a/.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl
@@ -23,4 +23,7 @@ else
   echo "        3. Enable 'Use the SSH Agent'"
   echo "        4. Verify: ssh -T git@github.com"
 fi
+echo "    Recommended for non-interactive tools (e.g. Claude Code) — see docs/1password.md:"
+echo "        - Settings > Developer > SSH Agent: 'Remember key approval' -> until 1Password locks"
+echo "        - Settings > Security > Auto-lock: extend idle timeout, disable 'Lock on sleep'"
 {{ end -}}

--- a/.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl
@@ -24,6 +24,6 @@ else
   echo "        4. Verify: ssh -T git@github.com"
 fi
 echo "    Recommended for non-interactive tools (e.g. Claude Code) — see docs/1password.md:"
-echo "        - Settings > Developer > SSH Agent: 'Remember key approval' -> until 1Password locks"
-echo "        - Settings > Security > Auto-lock: extend idle timeout, disable 'Lock on sleep'"
+echo "        - Settings > Developer > SSH Agent: 'Remember key approval' -> 'Until 1Password quits'"
+echo "        - Settings > Security > Auto-lock: extend idle timeout, disable lock-on-sleep"
 {{ end -}}

--- a/docs/1password.md
+++ b/docs/1password.md
@@ -115,38 +115,45 @@ chezmoi apply
 - シークレットの値はターゲットファイルに展開されるため、ターゲットファイル自体は Git 管理外（`~/.env` など）にしてください。
 - テンプレートソースファイル（`.tmpl`）にはシークレットの値ではなく **参照のみ** が含まれるため、安全にコミットできます。
 
-## SSH エージェントの承認とロック(Claude Code などの非対話ツール向け)
+## SSH エージェントの承認とロック（Claude Code などの非対話ツール向け）
 
-`~/.ssh/config` の `Host github.com` は 1Password SSH エージェント(`IdentityAgent`)を経由するため、
-`git push` などの SSH 接続には 1Password の承認(Touch ID / アプリ承認)が必要です。
+`~/.ssh/config` の `Host github.com` は 1Password SSH エージェント（`IdentityAgent`）を経由するため、
+`git push` などの SSH 接続には 1Password の承認（Touch ID / アプリ承認）が必要です。
 Claude Code のような非対話ツールは承認プロンプトに応答できないため、承認が切れた状態で
 push すると**応答待ちでハング**します。
 
 ### 仕組み
 
 - 鍵の使用要求ごとに 1Password が承認プロンプトを表示する。承認は**アプリケーション単位**で
-  記憶されるため、ターミナルから一度承認すれば、同じターミナル配下で動くツール(Claude Code 含む)は
+  記憶されるため、ターミナルから一度承認すれば、同じターミナル配下で動くツール（Claude Code 含む）は
   記憶が切れるまで再承認不要
-- 1Password が**ロック中**でもエージェントは動き続け、プロンプトを出して**応答があるまでブロック**する
-  (エラーにならず、SSH クライアント側からはハングに見える)
+- 承認の記憶期間（Remember key approval）は 3 択:
+  - **Until 1Password locks**（デフォルト）— ロックの度に承認が消える。**ハングの主因**
+  - **Until 1Password quits** — アプリを終了するまで承認を記憶
+  - **For a set amount of time**（4/12/24 時間）— ロックしても承認自体は維持
+- ただし 1Password が**ロック中**は承認が残っていても鍵にアクセスできず、エージェントは
+  解錠プロンプトを出して**応答があるまでブロック**する（エラーにならず、SSH クライアント側からは
+  ハングに見える）。そのため自動ロックの緩和もセットで必要
 
-### 推奨設定(1Password アプリの GUI 設定・chezmoi 管理外)
+### 推奨設定（1Password アプリの GUI 設定・chezmoi 管理外）
 
-1. **Settings → Developer**(SSH Agent): 「Remember key approval」を最長の
-   **until 1Password locks** に変更
-2. **Settings → Security**(Auto-lock):
-   - 「Lock after the system is idle for …」を長め(例: 8時間)に変更
-   - 「Lock on sleep, screensaver, or switching users」を**オフ**
+※ 表記はバージョンにより多少異なる
+
+1. **Settings → Developer**（SSH Agent）: Remember key approval を
+   **Until 1Password quits**（または For a set amount of time: 24 hours）に変更。
+   デフォルトの Until 1Password locks のままにしない
+2. **Settings → Security**（Auto-lock）: アイドル時の自動ロック時間を長め（例: 8 時間）にし、
+   スリープ・画面ロック時に 1Password をロックする設定をオフにする
 
 > **トレードオフ**: 離席中も 1Password が解錠されたままになる。macOS 側の画面ロック
-> (スリープ/スクリーンセーバーでの即時ロック)を必ず併用すること。
+> （スリープ/スクリーンセーバーでの即時ロック）を必ず併用すること。
 
 ### 残る制約
 
-- 再起動や明示的なロックの後は、初回のみターミナルからの承認が必要。長時間の作業セッションの
+- 再起動や明示的なロックの後は、初回のみターミナルからの承認・解錠が必要。長時間の作業セッションの
   前に `ssh -T git@github.com` を一度実行しておくと確実
 - それも許容できない場合は、GitHub 向け git 操作を HTTPS + `gh auth git-credential` に
-  切り替える選択肢がある(秘密鍵をディスクに置かずに非対話 push が可能)
+  切り替える選択肢がある（秘密鍵をディスクに置かずに非対話 push が可能）
 
 ## 参考リンク
 

--- a/docs/1password.md
+++ b/docs/1password.md
@@ -115,6 +115,39 @@ chezmoi apply
 - シークレットの値はターゲットファイルに展開されるため、ターゲットファイル自体は Git 管理外（`~/.env` など）にしてください。
 - テンプレートソースファイル（`.tmpl`）にはシークレットの値ではなく **参照のみ** が含まれるため、安全にコミットできます。
 
+## SSH エージェントの承認とロック(Claude Code などの非対話ツール向け)
+
+`~/.ssh/config` の `Host github.com` は 1Password SSH エージェント(`IdentityAgent`)を経由するため、
+`git push` などの SSH 接続には 1Password の承認(Touch ID / アプリ承認)が必要です。
+Claude Code のような非対話ツールは承認プロンプトに応答できないため、承認が切れた状態で
+push すると**応答待ちでハング**します。
+
+### 仕組み
+
+- 鍵の使用要求ごとに 1Password が承認プロンプトを表示する。承認は**アプリケーション単位**で
+  記憶されるため、ターミナルから一度承認すれば、同じターミナル配下で動くツール(Claude Code 含む)は
+  記憶が切れるまで再承認不要
+- 1Password が**ロック中**でもエージェントは動き続け、プロンプトを出して**応答があるまでブロック**する
+  (エラーにならず、SSH クライアント側からはハングに見える)
+
+### 推奨設定(1Password アプリの GUI 設定・chezmoi 管理外)
+
+1. **Settings → Developer**(SSH Agent): 「Remember key approval」を最長の
+   **until 1Password locks** に変更
+2. **Settings → Security**(Auto-lock):
+   - 「Lock after the system is idle for …」を長め(例: 8時間)に変更
+   - 「Lock on sleep, screensaver, or switching users」を**オフ**
+
+> **トレードオフ**: 離席中も 1Password が解錠されたままになる。macOS 側の画面ロック
+> (スリープ/スクリーンセーバーでの即時ロック)を必ず併用すること。
+
+### 残る制約
+
+- 再起動や明示的なロックの後は、初回のみターミナルからの承認が必要。長時間の作業セッションの
+  前に `ssh -T git@github.com` を一度実行しておくと確実
+- それも許容できない場合は、GitHub 向け git 操作を HTTPS + `gh auth git-credential` に
+  切り替える選択肢がある(秘密鍵をディスクに置かずに非対話 push が可能)
+
 ## 参考リンク
 
 - [chezmoi - 1Password](https://www.chezmoi.io/user-guide/password-managers/1password/)


### PR DESCRIPTION
## 概要

Claude Code など非対話ツールからの `git push` が、1Password SSH エージェントの承認待ちでハングする問題への runbook を追加する。

## 背景

`~/.ssh/config` の `Host github.com` は 1Password の `IdentityAgent` を経由するため、SSH push には 1Password の承認が必要。承認の記憶が切れている・1Password がロックされていると、エージェントはプロンプトを出して応答があるまでブロックし、非対話実行では push がハングする。

鍵はローカルに置かず 1Password に残したまま、**1Password 側の承認要件を GUI 設定で緩和する**方針(調査の結果、`agent.toml` は鍵の選択・順序のみで承認挙動は制御不可のため、chezmoi 管理対象は増やさない)。

## 変更内容

- **docs/1password.md**: 「SSH エージェントの承認とロック」セクションを追加。仕組み、推奨 GUI 設定(Remember key approval を until 1Password locks に / Auto-lock 緩和)、トレードオフ(macOS 画面ロック併用必須)、残る制約と HTTPS + `gh auth git-credential` の代替案を記載
- **.chezmoiscripts/run_once_after_10_notice-1password-ssh-agent.sh.tmpl**: apply 後の notice に推奨設定 2 点への案内を追記(内容変更により apply 時に一度再表示されるが echo のみで無害)

## 検証

- `make lint` パス
- pre-commit フック(shellcheck / chezmoi-template-check 含む)パス