### PR TITLE
fix(claude): use Edit(...) instead of Write(...) in permission rules

### DIFF
--- a/.chezmoitemplates/claude-settings-base.json
+++ b/.chezmoitemplates/claude-settings-base.json
@@ -13,9 +13,9 @@
       "Read(**)",
       "Read(~/.claude/**)",
       "Edit(**)",
-      "Write(**.md)",
-      "Write(/tmp/**)",
-      "Write(.tmp/**)",
+      "Edit(**.md)",
+      "Edit(/tmp/**)",
+      "Edit(.tmp/**)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
       "Bash(git status:*)",
@@ -131,7 +131,7 @@
       "Read(.env*)",
       "Read(id_rsa)",
       "Read(id_ed25519)",
-      "Write(.env*)"
+      "Edit(.env*)"
     ],
     "ask": ["Bash(gh pr merge:*)"],
     "defaultMode": "plan"


### PR DESCRIPTION
## Summary
- `claude -r` 実行時に、settings.json の permissions.allow/deny にある `Write(...)` ルールが「ファイル権限チェックでマッチしない」と警告されていた
- Edit ルールが Write を含む全てのファイル編集系ツールをカバーするため、該当4ルールを `Edit(...)` に置き換え
  - `Write(**.md)` → `Edit(**.md)`
  - `Write(/tmp/**)` → `Edit(/tmp/**)`
  - `Write(.tmp/**)` → `Edit(.tmp/**)`
  - `Write(.env*)` (deny) → `Edit(.env*)`

## Test plan
- [x] `python3 -m json.tool` で JSON構文を確認
- [x] `make lint` を実行し全チェックが通過することを確認
- [ ] マージ後、`chezmoi apply -- .chezmoitemplates/claude-settings-base.json .claude/settings.json` を実行し `claude -r` の警告が出ないことを確認