### PR TITLE
chore(claude): adopt CodeGraph section into CLAUDE.md

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -40,3 +40,14 @@ Project-specific instructions are in each project's `CLAUDE.md`.
 
 - Subject: ≤50 chars, imperative mood, no trailing period
 - Body: _what_ and _why_, not _how_; wrap at 72 chars
+
+<!-- CODEGRAPH_START -->
+## CodeGraph
+
+In repositories indexed by CodeGraph (a `.codegraph/` directory exists at the repo root), reach for it BEFORE grep/find or reading files when you need to understand or locate code:
+
+- **MCP tool** (when available): `codegraph_explore` answers most code questions in one call — the relevant symbols' verbatim source plus the call paths between them, including dynamic-dispatch hops grep can't follow. Name a file or symbol in the query to read its current line-numbered source. If it's listed but deferred, load it by name via tool search.
+- **Shell** (always works): `codegraph explore "<symbol names or question>"` prints the same output.
+
+If there is no `.codegraph/` directory, skip CodeGraph entirely — indexing is the user's decision.
+<!-- CODEGRAPH_END -->


### PR DESCRIPTION
## Summary
- The codegraph CLI installer (v1.3.1) had written a marker-fenced `<!-- CODEGRAPH_START -->`/`<!-- CODEGRAPH_END -->` section directly into the live `~/.claude/CLAUDE.md`, which was not yet tracked in the chezmoi source.
- Reconciled via the chezmoi↔~/.claude sync skill: `chezmoi re-add ~/.claude/CLAUDE.md` to bring this section into `dot_claude/CLAUDE.md` so it survives the next `chezmoi apply` instead of being silently overwritten.

## Out of scope
- `~/.claude/settings.json` also showed drift on `model` (live: `apac.anthropic.claude-sonnet-5` vs. overlay-managed `claude-sonnet-4-6`). This is company-overlay-managed (`~/.config/claude-overlay/overlay.jsonnet`), not part of this repo, so no change was made here — the overlay repo needs a separate update.

## Test plan
- [x] `chezmoi diff ~/.claude` shows no remaining drift for CLAUDE.md
- [x] `make lint` passes (JSON + template validation)