### PR TITLE
fix(install): stop cloning full nerd-fonts repo for fonts

### DIFF
--- a/.chezmoiscripts/run_once_install-fonts.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-fonts.sh.tmpl
@@ -14,13 +14,23 @@ if ls "${font_dir}"/UbuntuMono*.ttf >/dev/null 2>&1; then
   exit 0
 fi
 
+# nerd-fonts version: v3.4.0
+NERD_FONTS_VERSION="v3.4.0"
+
 log "Installing UbuntuMono Nerd Font..."
 tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
 
-git clone --branch=master --depth=1 https://github.com/ryanoasis/nerd-fonts.git "$tmpdir/nerd-fonts"
-cd "$tmpdir/nerd-fonts"
+curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/${NERD_FONTS_VERSION}/UbuntuMono.tar.xz" \
+  -o "$tmpdir/UbuntuMono.tar.xz"
+tar -xf "$tmpdir/UbuntuMono.tar.xz" -C "$tmpdir"
 
-./install.sh UbuntuMono
+for font in "$tmpdir"/*.ttf; do
+  install -Dm644 "$font" "${font_dir}/$(basename "$font")"
+done
 
-cd /
-rm -rf "$tmpdir"
+if command -v fc-cache >/dev/null 2>&1; then
+  fc-cache -f "${font_dir}"
+fi
+
+log "UbuntuMono Nerd Font installed"


### PR DESCRIPTION
## Summary

- The full `ryanoasis/nerd-fonts` repo bundles every patched font family, so even a shallow `git clone --depth=1` writes hundreds of MB into `.git` objects. On `playground01-stg`, `/tmp` is a small tmpfs that's nearly full, so the clone exhausted disk space and the install script failed.
- The script also had no cleanup trap, so a failed clone left partial data behind in `/tmp`.

## Fix

- Download only the `UbuntuMono.tar.xz` release asset (~2.3MB) from GitHub Releases (pinned to `v3.4.0`) instead of cloning the whole repo.
- Extract the tarball and install the `*.ttf` files directly with `install -Dm644`.
- Add `trap 'rm -rf "$tmpdir"' EXIT` right after creating the temp dir so cleanup always happens, even on failure.
- Run `fc-cache -f` after installing, guarded by `command -v fc-cache`.
- Preserve the existing "already installed" skip logic and `SKIP_NERD_FONTS_INSTALL` env var check unchanged.

## Test plan

- [x] `make lint` passes (JSON/tmpl/merge-patch checks)
- [x] Full `pre-commit run --all-files` passes (shellcheck, chezmoi template validation, gitleaks, etc.)
- [x] Rendered the template and ran it for real: confirmed all 12 `UbuntuMono*.ttf` files were installed under `~/.local/share/fonts`
- [x] Ran it a second time and confirmed it hit the "already installed, skipping" path
- [x] Cleaned up the test font files afterward so the local machine's font environment is unchanged