### PR TITLE
fix(install): support macOS in font install script

### DIFF
--- a/.chezmoiscripts/run_once_install-fonts.sh.tmpl
+++ b/.chezmoiscripts/run_once_install-fonts.sh.tmpl
@@ -8,7 +8,11 @@ if [[ "${SKIP_NERD_FONTS_INSTALL:-}" == "true" ]]; then
 fi
 
 # Check if UbuntuMono Nerd Font is already installed
+{{ if eq .chezmoi.os "darwin" -}}
+font_dir="${HOME}/Library/Fonts"
+{{ else -}}
 font_dir="${HOME}/.local/share/fonts"
+{{ end -}}
 if ls "${font_dir}"/UbuntuMono*.ttf >/dev/null 2>&1; then
   log "UbuntuMono Nerd Font is already installed, skipping"
   exit 0
@@ -25,8 +29,10 @@ curl -fsSL "https://github.com/ryanoasis/nerd-fonts/releases/download/${NERD_FON
   -o "$tmpdir/UbuntuMono.tar.xz"
 tar -xf "$tmpdir/UbuntuMono.tar.xz" -C "$tmpdir"
 
+# BSD install (macOS) has no -D, so create the target dir explicitly
+mkdir -p "${font_dir}"
 for font in "$tmpdir"/*.ttf; do
-  install -Dm644 "$font" "${font_dir}/$(basename "$font")"
+  install -m 644 "$font" "${font_dir}/"
 done
 
 if command -v fc-cache >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- PR #147 の `install -Dm644` は GNU coreutils 前提で、macOS の BSD install には `-D`(宛先ディレクトリ作成)がないため `chezmoi apply` が `INS@XXXX: No such file or directory` (exit 71) で失敗していた
- さらに macOS は fontconfig を使わないため、`~/.local/share/fonts` に置いてもフォントとして認識されない(正しくは `~/Library/Fonts`)。旧実装の nerd-fonts `install.sh` は OS 判定していたので Mac でも動いていた
- `font_dir` を `.chezmoi.os` で分岐(darwin → `~/Library/Fonts`)し、`install -D` を `mkdir -p` + `install -m 644` に置き換え(GNU/BSD 両対応、Linux 側は等価変換)

## Test plan
- [x] `make lint` 合格
- [x] `chezmoi execute-template` で darwin レンダリングが `~/Library/Fonts` になることを確認
- [x] レンダリング済みスクリプトを fake HOME で実行し、macOS BSD install でディレクトリ作成込みのインストール成功・2回目の idempotent skip を確認