### PR TITLE
fix(wezterm): make highlighted cell backgrounds translucent

### DIFF
--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -38,6 +38,8 @@ config.term = "xterm-256color"
 config.window_decorations = "RESIZE"
 config.enable_tab_bar = false
 config.window_background_opacity = 0.85
+-- 背景色付きセル(nvim の CursorLine 等)も同じ透明度で描画し、浮きを防ぐ
+config.text_background_opacity = 0.85
 config.scrollback_lines = 200
 config.automatically_reload_config = true
 if is_macos then


### PR DESCRIPTION
## 概要

catppuccin の `transparent_background` 有効化 (#114) 以降、背景色が明示されたセルだけが不透明のまま残り、透過した背景から浮いて見えていた。

- nvim のカーソル行 (`CursorLine`)
- nvim で markdown を開いたときの装飾部分の背景
- Claude Code TUI の自分の投稿の背景

## 原因

WezTerm は背景色付きセルを `text_background_opacity`(デフォルト 1.0 = 不透明)で描画するため、`window_background_opacity = 0.85` の効果が及ばない。

## 変更

`text_background_opacity = 0.85` を追加し、`window_background_opacity` と揃えることで、背景色付きハイライトも同じ透明度で描画されるようにした。fullscreen(背景写真)時もハイライト越しに写真が透けるようになる。

## 検証

- `make lint` パス
- `chezmoi diff --source <worktree>` で差分が意図した1箇所のみであることを確認