### PR TITLE
fix(wezterm): lower text_background_opacity to 0.75

### DIFF
--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -39,9 +39,9 @@ config.window_decorations = "RESIZE"
 config.enable_tab_bar = false
 config.window_background_opacity = 0.85
 -- 背景色付きセル(nvim の CursorLine 等)も透過させ、浮きを防ぐ。
--- 0.85 では全画面時の暗い背景写真がほぼ透けず体感差が無かったため、
--- 目視比較(0.75/0.60/0.45)で選んだ 0.75 に設定。
-config.text_background_opacity = 0.75
+-- 0.85 では全画面時の暗い背景写真がほぼ透けず体感差が無かった。
+-- 全画面相当の条件(背景写真+不透明)で 0.3/0.45/0.6 を目視比較して 0.45 を採用。
+config.text_background_opacity = 0.45
 config.scrollback_lines = 200
 config.automatically_reload_config = true
 if is_macos then

--- a/private_dot_config/wezterm/wezterm.lua
+++ b/private_dot_config/wezterm/wezterm.lua
@@ -38,8 +38,10 @@ config.term = "xterm-256color"
 config.window_decorations = "RESIZE"
 config.enable_tab_bar = false
 config.window_background_opacity = 0.85
--- 背景色付きセル(nvim の CursorLine 等)も同じ透明度で描画し、浮きを防ぐ
-config.text_background_opacity = 0.85
+-- 背景色付きセル(nvim の CursorLine 等)も透過させ、浮きを防ぐ。
+-- 0.85 では全画面時の暗い背景写真がほぼ透けず体感差が無かったため、
+-- 目視比較(0.75/0.60/0.45)で選んだ 0.75 に設定。
+config.text_background_opacity = 0.75
 config.scrollback_lines = 200
 config.automatically_reload_config = true
 if is_macos then


### PR DESCRIPTION
## 概要

#153 で追加した `text_background_opacity = 0.85` は、体感で違いが分からなかった(特に全画面時は背景写真が brightness 0.07 までしか明るくないため、15% の透過ではほぼ見えない)。

## 検証

- ウィンドウ単体キャプチャで 0.2 設定時に色帯が washed-out になることを確認 → 機構自体は動作している(値が控えめすぎただけ)
- 0.75 / 0.60 / 0.45 のテストウィンドウを並べて目視比較し、0.75 を選定

## 変更

`text_background_opacity` を 0.85 → 0.75 に変更し、選定理由をコメントに記載。