### PR TITLE
fix(tmux): make status bar background transparent

### DIFF
--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -106,6 +106,9 @@ run '~/.tmux/plugins/tpm/tpm'
 # -----------------------
 # Pane Style (after TPM to override Catppuccin)
 # -----------------------
+# Catppuccin はステータスバーの地に base 色を明示するため、端末の透過が
+# 効かず不透明の帯になる。bg=default で地を端末背景(透過)に戻す。
+set -g status-style bg=default
 set -g window-style 'bg=default'
 set -g window-active-style 'bg=default'
 set -g pane-border-style 'fg=#6c7086'


### PR DESCRIPTION
## 概要

Catppuccin テーマがステータスバーの地に base 色を明示するため、透過背景の上に不透明な帯として浮いていた(#153 / #154 の透過対応の続き)。

## 変更

TPM 実行後の override セクションに `set -g status-style bg=default` を追加。バーの地は端末背景(透過)を継承し、モジュールのピル部分は wezterm の `text_background_opacity = 0.45` で半透明になる。

## 検証

テスト用 tmux サーバー(`tmux -L transtest -f <worktree>/dot_tmux.conf`)を全画面相当の wezterm ミミック窓に attach し、スクリーンショットでバーの地が透過することを確認済み。