### PR TITLE
feat(zsh): tint sshf pane by target environment

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -156,4 +156,4 @@ Telescope ウィンドウ内:
 | `Ctrl+R` | コマンド履歴検索 (Atuin) |
 | `g` | ghq + fzf でリポジトリ移動 |
 | `vim` | nvim のエイリアス |
-| `sshf` | fzf で SSH ホストを選択して接続 |
+| `sshf` | fzf で SSH ホストを選択して接続（ホスト名に `dev`/`stg`/`prod` を含む場合、接続中はペイン背景を紫/緑/赤に着色） |

--- a/private_dot_config/zsh/functions.zsh
+++ b/private_dot_config/zsh/functions.zsh
@@ -1,3 +1,44 @@
+# Environment tint for sshf: colour the pane background while connected, so a
+# prod shell never looks like a dev shell. wezterm's text_background_opacity
+# keeps these translucent, so they read as a tint over the desktop/photo
+# rather than an opaque block — keep them dark and low-saturation.
+typeset -gA SSHF_ENV_COLORS=(
+  prod '#3d1b1b'
+  stg  '#16301f'
+  dev  '#2d1b3d'
+)
+
+# Classify a host name into prod / stg / dev. Most dangerous wins, so a host
+# like "stg-to-prod-sync" is treated as prod. "stg" also covers stgqa/stg-qa.
+function _sshf_env_for_host() {
+  case "${1:l}" in
+    *prod*) print -r -- prod ;;
+    *stg*) print -r -- stg ;;
+    *dev*) print -r -- dev ;;
+  esac
+}
+
+# Tint only the pane running ssh. Inside tmux that means pane-scoped options
+# (tmux swallows raw OSC unless allow-passthrough is on, and window-style would
+# repaint every pane in the window); bare wezterm falls back to OSC 11.
+function _sshf_tint_on() {
+  if [[ -n "$TMUX" && -n "$TMUX_PANE" ]]; then
+    tmux set-option -p -t "$TMUX_PANE" window-style "bg=$1"
+    tmux set-option -p -t "$TMUX_PANE" window-active-style "bg=$1"
+  else
+    printf '\e]11;%s\a' "$1"
+  fi
+}
+
+function _sshf_tint_off() {
+  if [[ -n "$TMUX" && -n "$TMUX_PANE" ]]; then
+    tmux set-option -p -u -t "$TMUX_PANE" window-style
+    tmux set-option -p -u -t "$TMUX_PANE" window-active-style
+  else
+    printf '\e]111\a'
+  fi
+}
+
 # SSH shortcut with fzf
 function sshf() {
   # Listing Host and HostName from ~/.ssh/config and selecting with fzf
@@ -11,7 +52,15 @@ function sshf() {
 
   # If a selection was made, initiate SSH connection
   if [ -n "$selection" ]; then
-    ssh "$@""$selection"
+    local sshf_env
+    sshf_env=$(_sshf_env_for_host "$selection")
+    [[ -n "$sshf_env" ]] && _sshf_tint_on "$SSHF_ENV_COLORS[$sshf_env]"
+    # `always` also runs on interrupt, so Ctrl-C never leaves the pane tinted.
+    {
+      ssh "$@""$selection"
+    } always {
+      [[ -n "$sshf_env" ]] && _sshf_tint_off
+    }
   fi
 }
 


### PR DESCRIPTION
## Context

`sshf` で接続した後、prod のシェルと dev のシェルが見た目で区別できなかった。接続先ホスト名から環境を判定し、**接続中だけそのペインの背景を着色**する。

| 環境 | 判定 | 色 |
|---|---|---|
| prod | `*prod*` | 赤 `#3d1b1b` |
| stg | `*stg*`（`stgqa`/`stg-qa` を含む） | 緑 `#16301f` |
| dev | `*dev*` | 紫 `#2d1b3d` |

判定は**危険側優先**（prod > stg > dev）。`stg-to-prod-sync` は赤になる。

## 実装上の判断

- **ペインスコープの tmux オプション**（`set -p window-style` / `window-active-style`）を使う。`window-style` をウィンドウスコープで設定すると同じ tmux ウィンドウの全ペインが塗られてしまい、「ssh している部分だけ」にならない
- **生の OSC は使わない**（tmux 内では）。`allow-passthrough` が off のため tmux に飲まれる。有効化すると DCS ラップが必要な上、wezterm ペイン単位＝tmux 全ペインが対象になり粒度が粗い
- tmux 外では **OSC 11 / OSC 111** にフォールバック
- **透過**は wezterm 側の `text_background_opacity = 0.45`（#153-155）に乗る。背景色付きセルが自動的に透けるため、不透明な帯ではなく背景写真越しの淡い色味になる
- 復元は zsh の `{ } always { }` ブロック。**Ctrl-C で中断しても色が残らない**

既存の `ssh "$@""$selection"` の引数連結（`sshf root@` で `ssh root@host` になる形）は意図的な挙動の可能性があるため、**そのまま維持**した。

## Verification

**1. 分類ロジック** — 11 ケース全パス
```
ok dev-api -> dev        ok stg-web   -> stg    ok prod-db          -> prod
ok my-dev-batch -> dev   ok stgqa-web -> stg    ok prod01           -> prod
ok DEV-UPPER -> dev      ok stg-qa-web-> stg    ok stg-to-prod-sync -> prod
ok github.com -> (none)  ok bastion   -> (none)
```

**2. ペイン単位の適用と復元** — 2 ペインの tmux セッションで、`ssh` をスタブ化して SIGINT を送出
```
before               : %8(TARGET)=[]            %9(other)=[]
while connected(prod): %8(TARGET)=[bg=#3d1b1b]  %9(other)=[]     ← 対象ペインのみ
after Ctrl-C         : %8(TARGET)=[]            %9(other)=[]     ← always で復元
```

**3. 実描画** — 4 ペイン（dev/stg/prod/無着色）を実 wezterm ウィンドウに attach して `screencapture`。3 色が識別可能かつ背景写真越しに透過していることを目視確認。

**4. lint** — `make lint` 全パス、`zsh -n` 構文チェック OK、pre-commit 全パス。